### PR TITLE
Add support for Fingerbot Plus with product_id h8kdwywx

### DIFF
--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -95,6 +95,7 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
                     "yiihr7zh",
                     "neq16kgd",
                     "6jcvqwh0",
+                    "h8kdwywx",
                 ],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotModeMapping(dp_id=2),

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -408,6 +408,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                     "neq16kgd",
                     "6jcvqwh0",
                     "riecov42",
+                    "h8kdwywx",
                 ],  # device product_ids
                 TuyaBLEProductInfo(
                     name="Fingerbot Plus",

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -276,6 +276,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     "neq16kgd",
                     "6jcvqwh0",
                     "riecov42",
+                    "h8kdwywx",
                 ],  # Fingerbot Plus
                 [
                     TuyaBLENumberMapping(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -230,6 +230,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                     "neq16kgd",
                     "6jcvqwh0",
                     "riecov42",
+                    "h8kdwywx",
                 ],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotModeMapping(dp_id=8),

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -284,6 +284,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     "neq16kgd",
                     "6jcvqwh0",
                     "riecov42",
+                    "h8kdwywx",
                 ],  # Fingerbot Plus
                 [
                     TuyaBLEBatteryMapping(dp_id=12),

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -255,6 +255,7 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     "neq16kgd",
                     "6jcvqwh0",
                     "riecov42",
+                    "h8kdwywx",
                 ],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotSwitchMapping(dp_id=2),

--- a/custom_components/tuya_ble/text.py
+++ b/custom_components/tuya_ble/text.py
@@ -125,6 +125,7 @@ mapping: dict[str, TuyaBLECategoryTextMapping] = {
                     "neq16kgd",
                     "6jcvqwh0",
                     "riecov42",
+                    "h8kdwywx",
                 ],  # Fingerbot Plus
                 [
                     TuyaBLETextMapping(


### PR DESCRIPTION
First of all, I would very much like to thank you and @PlusPlus-ua for your contributions!

Would very much like if you could merge my PR, so we can avoid another fork, hehe

I got myself a [Finger Bot](https://www.amazon.co.jp/gp/product/B0BRSC6SYD) from Amazon:

* Brand: +Style (プラススタイル)
* Manufacturer: BBソフトサービス株式会社
* Item Model Number: PS-SWI-B01

After adding it to Smart Life (instead of using the official app), I got this information from the [Tuya Developer Platform](https://us.platform.tuya.com/):

```json
{
  "result": [
    {
      "active_time": 1746930833,
      "bind_space_id": "32329756",
      "category": "szjqr",
      "create_time": 1746849977,
      "custom_name": "Fingerbot",
      "icon": "smart/icon/ay1535356536379kshGf/d3c0430ccbd815b837d6634e5c9bdce0.png",
      "id": "eb0142xxxxxxxxxx",
      "ip": "",
      "is_online": false,
      "lat": "0.0",
      "local_key": "xxxxxxxxxx",
      "lon": "0.0",
      "model": "",
      "name": "Fingerbot",
      "product_id": "h8kdwywx",
      "product_name": "HYFB0001_スイッチ",
      "sub": false,
      "time_zone": "+09:00",
      "update_time": 1746930858,
      "uuid": "tuyac10xxxxxxxxxx"
    }
  ],
  "success": true,
  "t": 1746931587316,
  "tid": "xxxxxxxxxx"
}
```

I can't compare it to any other Finger Bot, but it seems to work nicely from Home Assistant.

![Screenshot 2025-05-11 at 12 18 34](https://github.com/user-attachments/assets/4e5c1f51-7a1b-497f-8d8e-db86dc0ea694)