### PR TITLE
Improve debug logging of cloud API details

### DIFF
--- a/custom_components/tuya_ble/tuya_ble/manager.py
+++ b/custom_components/tuya_ble/tuya_ble/manager.py
@@ -34,7 +34,7 @@ class TuyaBLEDeviceCredentials:
             "status_range: %s"
         ) % (
             self.uuid,
-            f'{"x" * 14}{self.local_key[14:]}',  # Mask the majority of the local key
+            f'{"x" * 10}{self.local_key[10:]}',  # Mask the majority of the local key
             self.device_id,
             self.category,
             self.product_id,

--- a/custom_components/tuya_ble/tuya_ble/manager.py
+++ b/custom_components/tuya_ble/tuya_ble/manager.py
@@ -22,9 +22,9 @@ class TuyaBLEDeviceCredentials:
 
     def __str__(self):
         return (
-            "uuid: xxxxxxxxxxxxxxxx, "
-            "local_key: xxxxxxxxxxxxxxxx, "
-            "device_id: xxxxxxxxxxxxxxxx, "
+            "uuid: %s, "
+            "local_key: %s, "
+            "device_id: %s, "
             "category: %s, "
             "product_id: %s, "
             "device_name: %s, "
@@ -33,6 +33,9 @@ class TuyaBLEDeviceCredentials:
             "functions: %s"
             "status_range: %s"
         ) % (
+            self.uuid,
+            f'{"x" * 14}{self.local_key[14:]}',  # Mask the majority of the local key
+            self.device_id,
             self.category,
             self.product_id,
             self.device_name,


### PR DESCRIPTION
Before:
```
2025-05-11 14:29:44.958 DEBUG (MainThread) [custom_components.tuya_ble.cloud] Retrieved: uuid: xxxxxxxxxxxxxxxx, local_key: xxxxxxxxxxxxxxxx, device_id: xxxxxxxxxxxxxxxx, category: kg, product_id: mknd4lci, device_name: Finger Robot, product_model: BS-FB-V3.1, product_name: Finger Robotfunctions: [{'code': 'switch_1', 'dp_id': 1, 'type': 'Boolean', 'values': '{}'}]status_range: [{'code': 'switch_1', 'dp_id': 1, 'type': 'Boolean', 'values': '{}'}]
```

- Stop masking device id, uuid
- Only partially mask local key
