### PR TITLE
Add further B16 (ajk32biq) support

### DIFF
--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -114,19 +114,19 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
             ),
         }
     ),
-    # "jtmspro": TuyaBLECategoryBinarySensorMapping(
-    #     products={
-    #         "ajk32biq": [
-    #             TuyaBLEBinarySensorMapping(
-    #                 dp_id=24,
-    #                 description=BinarySensorEntityDescription(
-    #                     key="doorbell",
-    #                     device_class=BinarySensorDeviceClass.DOORBELL,
-    #                 ),
-    #             ),
-    #         ],
-    #     }
-    # ),
+    "jtmspro": TuyaBLECategoryBinarySensorMapping(
+        products={
+            "ajk32biq": [
+                TuyaBLEBinarySensorMapping(
+                    dp_id=24,
+                    description=BinarySensorEntityDescription(
+                        key="doorbell",
+                        device_class=BinarySensorDeviceClass.DOORBELL,
+                    ),
+                ),
+            ],
+        }
+    ),
 }
 
 

--- a/custom_components/tuya_ble/lock.py
+++ b/custom_components/tuya_ble/lock.py
@@ -5,6 +5,7 @@ from typing import Any
 from homeassistant.components.lock import LockEntity, LockEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, DPCode
@@ -38,7 +39,13 @@ class TuyaBLELock(TuyaBLEEntity, LockEntity):
         device: TuyaBLEDevice,
         product: TuyaBLEProductInfo,
     ) -> None:
-        super().__init__(hass, coordinator, device, product, None)
+        super().__init__(
+            hass,
+            coordinator,
+            device,
+            product,
+            EntityDescription(key="lock", name=None),
+        )
         self._attr_supported_features = LockEntityFeature.OPEN
 
     @property

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -296,7 +296,6 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                     "xicdxood",  # Raycube K7 Pro+
                     "rlyxv7pe",  # A1 PRO MAX - Experimental
                     "oyqux5vv",  # LA-01 - Experimental
-                    "ajk32biq",  # B16
                     "z7lj676i",  # Smart Cylinder Lock - Experimental
                 ],
                 [  # Raycube K7 Pro+
@@ -323,44 +322,73 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                                 "Arabic",
                                 "Indonesian",
                                 "Portuguese",
-                                "Russian",
-                                "Spanish",
-                                "Thai",
-                                "Vietnamese",
-                            ],
-                            entity_category=EntityCategory.CONFIG,
-                        ),
-                    ),
-                    TuyaBLESelectMapping(
-                        dp_id=89,
-                        description=SelectEntityDescription(
-                            key="autolock_delay",
-                            options=[
-                                "Inactive",
-                                "4s",
-                                "6s",
-                                "8s",
-                                "10s",
-                                "12s",
-                            ],
-                            entity_category=EntityCategory.CONFIG,
-                        ),
-                    ),
-                    TuyaBLESelectMapping(
-                        dp_id=34,
-                        description=SelectEntityDescription(
-                            key="double_verification",
-                            options=[
-                                "Single Unlock",
-                                "Combination Unlock",
                             ],
                             entity_category=EntityCategory.CONFIG,
                         ),
                     ),
                 ],
-            )
-        }
-    ),
+            ),
+            "ajk32biq": [
+                TuyaBLESelectMapping(
+                    dp_id=31,
+                    description=SelectEntityDescription(
+                        key="beep_volume",
+                        options=[
+                            "Mute",
+                            "Low",
+                            "Normal",
+                            "High",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESelectMapping(
+                    dp_id=28,
+                    description=SelectEntityDescription(
+                        key="language",
+                        options=[
+                            "Chinese Simplified",
+                            "English",
+                            "Arabic",
+                            "Indonesian",
+                            "Portuguese",
+                            "Russian",
+                            "Spanish",
+                            "Thai",
+                            "Vietnamese",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESelectMapping(
+                    dp_id=89,
+                    description=SelectEntityDescription(
+                        key="autolock_delay",
+                        options=[
+                            "Inactive",
+                            "4s",
+                            "6s",
+                            "8s",
+                            "10s",
+                            "12s",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESelectMapping(
+                    dp_id=34,
+                    description=SelectEntityDescription(
+                        key="double_verification",
+                        options=[
+                            "Single Unlock",
+                            "Combination Unlock",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                ],
+            }
+        ),
     "szjqr": TuyaBLECategorySelectMapping(
         products={
             **dict.fromkeys(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -323,6 +323,36 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                                 "Arabic",
                                 "Indonesian",
                                 "Portuguese",
+                                "Russian",
+                                "Spanish",
+                                "Thai",
+                                "Vietnamese",
+                            ],
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                    TuyaBLESelectMapping(
+                        dp_id=89,
+                        description=SelectEntityDescription(
+                            key="autolock_delay",
+                            options=[
+                                "Inactive",
+                                "4s",
+                                "6s",
+                                "8s",
+                                "10s",
+                                "12s",
+                            ],
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                    TuyaBLESelectMapping(
+                        dp_id=34,
+                        description=SelectEntityDescription(
+                            key="double_verification",
+                            options=[
+                                "Single Unlock",
+                                "Combination Unlock",
                             ],
                             entity_category=EntityCategory.CONFIG,
                         ),

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -384,11 +384,11 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                             "Combination Unlock",
                         ],
                         entity_category=EntityCategory.CONFIG,
-                        ),
                     ),
-                ],
-            }
-        ),
+                ),
+            ],
+        }
+    ),
     "szjqr": TuyaBLECategorySelectMapping(
         products={
             **dict.fromkeys(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -315,6 +315,20 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                             icon="mdi:keyboard-outline",
                         ),
                     ),
+                    TuyaBLESensorMapping(
+                        dp_id=19,  # Retrieve last bluetooth unlock used
+                        description=SensorEntityDescription(
+                            key="unlock_ble",
+                            icon="mdi:bluetooth",
+                        ),
+                    ),
+                    TuyaBLESensorMapping(
+                        dp_id=14,  # Retrieve last dynamic password used
+                        description=SensorEntityDescription(
+                            key="unlock_dynamic",
+                            icon="mdi:lock-reset",
+                        ),
+                    ),
                     TuyaBLEBatteryMapping(dp_id=8),
                 ],
             ),

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -289,7 +289,6 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     "xicdxood",  # Raycube K7 Pro+
                     "rlyxv7pe",  # A1 PRO MAX - Experimental
                     "oyqux5vv",  # LA-01 - Experimental
-                    "ajk32biq",  # B16
                     "z7lj676i",  # Smart Cylinder Lock - Experimental
                 ],
                 [
@@ -315,23 +314,48 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                             icon="mdi:keyboard-outline",
                         ),
                     ),
-                    TuyaBLESensorMapping(
-                        dp_id=19,  # Retrieve last bluetooth unlock used
-                        description=SensorEntityDescription(
-                            key="unlock_ble",
-                            icon="mdi:bluetooth",
-                        ),
-                    ),
-                    TuyaBLESensorMapping(
-                        dp_id=14,  # Retrieve last dynamic password used
-                        description=SensorEntityDescription(
-                            key="unlock_dynamic",
-                            icon="mdi:lock-reset",
-                        ),
-                    ),
                     TuyaBLEBatteryMapping(dp_id=8),
                 ],
             ),
+            "ajk32biq": [
+                TuyaBLEAlarmLockStateMapping(dp_id=21),
+                TuyaBLESensorMapping(
+                    dp_id=12,  # Retrieve last fingerprint used
+                    description=SensorEntityDescription(
+                        key="unlock_fingerprint",
+                        icon="mdi:fingerprint",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=15,  # Retrieve last card used
+                    description=SensorEntityDescription(
+                        key="unlock_card",
+                        icon="mdi:nfc-variant",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=13,  # Retrieve last code used
+                    description=SensorEntityDescription(
+                        key="unlock_password",
+                        icon="mdi:keyboard-outline",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=19,  # Retrieve last bluetooth unlock used
+                    description=SensorEntityDescription(
+                        key="unlock_ble",
+                        icon="mdi:bluetooth",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=14,  # Retrieve last dynamic password used
+                    description=SensorEntityDescription(
+                        key="unlock_dynamic",
+                        icon="mdi:lock-reset",
+                    ),
+                ),
+                TuyaBLEBatteryMapping(dp_id=8),
+            ],
         }
     ),
     "szjqr": TuyaBLECategorySensorMapping(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -242,32 +242,23 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
     ),
     "jtmspro": TuyaBLECategorySwitchMapping(
         products={
-            **dict.fromkeys(
-                [
-                    "xicdxood",
-                    "oyqux5vv",
-                    "rlyxv7pe",
-                    "ajk32biq",
-                    "z7lj676i",
-                ],
-                [
-                    TuyaBLESwitchMapping(
-                        dp_id=33,
-                        description=SwitchEntityDescription(
-                            key="automatic_lock",
-                            icon="mdi:lock-clock",
-                            entity_category=EntityCategory.CONFIG,
-                        ),
+            "ajk32biq": [
+                TuyaBLESwitchMapping(
+                    dp_id=33,
+                    description=SwitchEntityDescription(
+                        key="automatic_lock",
+                        icon="mdi:lock-clock",
+                        entity_category=EntityCategory.CONFIG,
                     ),
-                    TuyaBLESwitchMapping(
-                        dp_id=46,
-                        description=SwitchEntityDescription(
-                            key="manual_lock",
-                            icon="mdi:lock-plus",
-                        ),
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=46,
+                    description=SwitchEntityDescription(
+                        key="manual_lock",
+                        icon="mdi:lock-plus",
                     ),
-                ],
-            ),
+                ),
+            ],
         }
     ),
     "szjqr": TuyaBLECategorySwitchMapping(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -240,6 +240,36 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
             ),
         }
     ),
+    "jtmspro": TuyaBLECategorySwitchMapping(
+        products={
+            **dict.fromkeys(
+                [
+                    "xicdxood",
+                    "oyqux5vv",
+                    "rlyxv7pe",
+                    "ajk32biq",
+                    "z7lj676i",
+                ],
+                [
+                    TuyaBLESwitchMapping(
+                        dp_id=33,
+                        description=SwitchEntityDescription(
+                            key="automatic_lock",
+                            icon="mdi:lock-clock",
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                    TuyaBLESwitchMapping(
+                        dp_id=46,
+                        description=SwitchEntityDescription(
+                            key="manual_lock",
+                            icon="mdi:lock-plus",
+                        ),
+                    ),
+                ],
+            ),
+        }
+    ),
     "szjqr": TuyaBLECategorySwitchMapping(
         products={
             **dict.fromkeys(


### PR DESCRIPTION
Fix https://github.com/ha-tuya-ble/ha_tuya_ble/issues/121

This change fixes a critical bug in the lock platform where the `TuyaBLELock` was initialized with a `None` description, causing an `AttributeError` that prevented any entities from being loaded for lock devices.

Additionally, it adds comprehensive support for the Tuya BLE Lock B16 (product ID `ajk32biq`, category `jtmspro`) by mapping the following Data Points:
- DP 24: Doorbell (Binary Sensor)
- DP 33: Automatic Lock (Switch)
- DP 46: Manual Lock (Switch)
- DP 14: Dynamic Password Unlock (Sensor)
- DP 19: BLE Unlock (Sensor)
- DP 28: Language (Select)
- DP 34: Double Verification (Select)
- DP 89: Autolock Delay (Select)

---
*PR created automatically by Jules for task [5131709371086883041](https://jules.google.com/task/5131709371086883041) started by @CloCkWeRX*