### PR TITLE
Add support for Switch Robot (kg / 4ctjfrzq)

### DIFF
--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -511,6 +511,9 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                     ),
                 ),
             ),
+            "4ctjfrzq": TuyaBLEProductInfo(
+                name="Switch Robot",
+            ),
         },
     ),
     "wk": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -349,6 +349,14 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     ),
                 ],
             ),
+            "4ctjfrzq": [
+                TuyaBLESwitchMapping(
+                    dp_id=1,
+                    description=SwitchEntityDescription(
+                        key="switch",
+                    ),
+                ),
+            ],
         },
     ),
     "wk": TuyaBLECategorySwitchMapping(


### PR DESCRIPTION
Add support for the Tuya BLE Switch Robot (SB02), product ID 4ctjfrzq, category kg.

This device exposes a single Boolean function (switch_1), so only devices.py and switch.py needed changes.

Tested locally:
- discovered over BLE
- added successfully
- switch entity created
- switching works
- still works after Home Assistant restart

AI-assisted, manually tested on dockerised HA 2026.04.

Tuya specificaiton:
`{
  "result": {
    "category": "kg",
    "functions": [
      {
        "code": "switch_1",
        "desc": "{}",
        "name": "开关1",
        "type": "Boolean",
        "values": "{}"
      }
    ],
    "status": [
      {
        "code": "switch_1",
        "name": "开关1",
        "type": "Boolean",
        "values": "{}"
      }
    ]
  },
  "success": true
}`

