### PR TITLE
Fix documentation URL in manifest.json

### DIFF
--- a/custom_components/tuya_ble/manifest.json
+++ b/custom_components/tuya_ble/manifest.json
@@ -10,7 +10,7 @@
   "codeowners": ["@PlusPlus-ua", "@Snuffy2", "@kancelott", "@scastiello", "@CloCkWeRX"],
   "config_flow": true,
   "dependencies": ["bluetooth_adapters", "tuya"],
-  "documentation": "https://github.com/ha_tuya_ble/ha_tuya_ble",
+  "documentation": "https://github.com/ha-tuya-ble/ha_tuya_ble",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ha-tuya-ble/ha_tuya_ble/issues",
   "requirements": ["tuya-iot-py-sdk==0.6.6", "pycountry>23.0.0"],


### PR DESCRIPTION
Fixed wrong URL, prior referring to non-existing github repo 'ha_tuya_ble'. Corrected to 'ha-tuya-ble'.