### PR TITLE
Add support for jtmspro hs21i377 smart lock

### DIFF
--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -114,6 +114,19 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
             ),
         }
     ),
+    "jtmspro": TuyaBLECategoryBinarySensorMapping(
+        products={
+            "hs21i377": [
+                TuyaBLEBinarySensorMapping(
+                    dp_id=47,
+                    description=BinarySensorEntityDescription(
+                        key="lock_motor_state",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+            ],
+        },
+    ),
     # "jtmspro": TuyaBLECategoryBinarySensorMapping(
     #     products={
     #         "ajk32biq": [

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -187,7 +187,17 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
                         ),
                     ),
                 ],
-            )
+            ),
+            "hs21i377": [
+                TuyaBLEButtonMapping(
+                    dp_id=71,
+                    description=ButtonEntityDescription(
+                        key="bluetooth_unlock",
+                        icon="mdi:lock-open-check-outline",
+                    ),
+                    dp_type=TuyaBLEDataPointType.DT_RAW,
+                ),
+            ],
         },
     ),
     "ms": TuyaBLECategoryButtonMapping(
@@ -240,8 +250,30 @@ class TuyaBLEButton(TuyaBLEEntity, ButtonEntity):
         super().__init__(hass, coordinator, device, product, mapping.description)
         self._mapping = mapping
 
+    async def _run_hs21i377_unlock(self) -> None:
+        """Run the validated dp71 unlock flow for hs21i377."""
+        # hs21i377 uses a device-specific dp71 unlock payload.
+        # Practical testing confirmed multiple payload variants can unlock,
+        # so this is not treated as a fixed "known lock code". We keep an
+        # empirically validated value here until the payload semantics are
+        # understood better.
+        dp71_value = bytes.fromhex("0001ffff36383538313536320169ab34cd0000")
+
+        dp71 = self._device.datapoints.get_or_create(
+            71,
+            TuyaBLEDataPointType.DT_RAW,
+            b"",
+        )
+        if dp71:
+            await dp71.set_value(dp71_value)
+
     def press(self) -> None:
         """Press the button."""
+        if self._device.product_id == "hs21i377":
+            if self._mapping.description.key == "bluetooth_unlock":
+                self._hass.create_task(self._run_hs21i377_unlock())
+                return
+
         datapoint = self._device.datapoints.get_or_create(
             self._mapping.dp_id,
             TuyaBLEDataPointType.DT_BOOL,

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -407,6 +407,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             "ebd5e0uauqx0vfsp": TuyaBLEProductInfo(name="CentralAcesso"),
             "ajk32biq": TuyaBLEProductInfo(name="B16", lock=1),
             "z7lj676i": TuyaBLEProductInfo(name="Smart Cylinder Lock", lock=1),
+            "hs21i377": TuyaBLEProductInfo(name="Smart Cylinder Lock"),
         },
     ),
     "szjqr": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -312,6 +312,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     "oyqux5vv",  # LA-01 - Experimental
                     "ajk32biq",  # B16
                     "z7lj676i",  # Smart Cylinder Lock - Experimental
+                    "hs21i377",  # Smart Cylinder Lock (LVD11_BK)
                 ],
                 [
                     TuyaBLEAlarmLockStateMapping(dp_id=21),


### PR DESCRIPTION
## Summary

Add support for the tested `jtmspro` smart lock with product id `hs21i377` (model `LVD11_BK`).

This PR keeps the scope intentionally narrow and only adds support for the specific product that was tested on real hardware.

## What is added

- product definition for `jtmspro` / `hs21i377`
- existing `jtmspro` smart-lock sensor mapping enabled for this product
- diagnostic binary sensor for lock motor state (`dp47`)
- product-specific Bluetooth unlock button using the validated `dp71` RAW payload path

## Notes

The standard Home Assistant lock entity is intentionally not added for this product.

During testing, a reliable generic locked/unlocked behavior for the usual lock entity could not be confirmed cleanly enough, while the following entities were confirmed useful:

- RSSI
- battery
- lock motor state
- Bluetooth unlock button

Some inherited smart-lock sensor values also appeared for this product, but their practical meaning is still unclear, for example:

- alarm lock
- last used card
- last used fingerprint
- last used password

## Testing

Tested on a real `jtmspro` / `hs21i377` / `LVD11_BK` device.

Confirmed behavior:

- device can be added successfully
- battery entity is available
- motor state diagnostic entity is available
- Bluetooth unlock button works
- support is limited to this tested product and does not change generic button handling for other products

## Implementation detail

Unlock is handled through a product-specific `dp71` RAW payload for `hs21i377`.

The payload semantics are not fully understood yet, but the current value was validated empirically on the physical device and kept isolated to this product only.