### PR TITLE
Add support to ZX-7378 Smart Irrigation Controller (product: ldcdnigc)

### DIFF
--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -163,6 +163,7 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
                     description=BinarySensorEntityDescription(
                         key="lack_water",
                         name="Lack of Water",
+                        device_class=BinarySensorDeviceClass.PROBLEM,
                         icon="mdi:water-off",
                         entity_category=EntityCategory.DIAGNOSTIC,
                     ),

--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -43,6 +43,7 @@ class TuyaBLEBinarySensorMapping:
     force_add: bool = True
     dp_type: TuyaBLEDataPointType | None = None
     getter: Callable[[TuyaBLEBinarySensor], None] | None = None
+    bit: int | None = None
     # coefficient: float = 1.0
     # icons: list[str] | None = None
     is_available: TuyaBLEBinarySensorIsAvailable = None
@@ -114,6 +115,87 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
             ),
         }
     ),
+    "sfkzq": TuyaBLECategoryBinarySensorMapping(
+        products={
+            "ldcdnigc": [
+                TuyaBLEBinarySensorMapping(
+                    dp_id=1,
+                    dp_type=TuyaBLEDataPointType.DT_BOOL,
+                    description=BinarySensorEntityDescription(
+                        key="switch",
+                        name="Switch status",
+                        device_class=BinarySensorDeviceClass.OPENING,
+                    ),
+                ),
+                TuyaBLEBinarySensorMapping(
+                    dp_id=4,
+                    dp_type=TuyaBLEDataPointType.DT_BITMAP,
+                    bit=0,
+                    description=BinarySensorEntityDescription(
+                        key="low_battery",
+                        name="Low Battery",
+                        device_class=BinarySensorDeviceClass.BATTERY,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLEBinarySensorMapping(
+                    dp_id=4,
+                    dp_type=TuyaBLEDataPointType.DT_BITMAP,
+                    bit=1,
+                    description=BinarySensorEntityDescription(
+                        key="fault",
+                        name="Fault",
+                        device_class=BinarySensorDeviceClass.PROBLEM,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLEBinarySensorMapping(
+                    dp_id=4,
+                    dp_type=TuyaBLEDataPointType.DT_BITMAP,
+                    bit=2,
+                    description=BinarySensorEntityDescription(
+                        key="lack_water",
+                        name="Lack of Water",
+                        icon="mdi:water-off",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLEBinarySensorMapping(
+                    dp_id=4,
+                    dp_type=TuyaBLEDataPointType.DT_BITMAP,
+                    bit=3,
+                    description=BinarySensorEntityDescription(
+                        key="sensor_fault",
+                        name="Sensor Fault",
+                        device_class=BinarySensorDeviceClass.PROBLEM,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLEBinarySensorMapping(
+                    dp_id=4,
+                    dp_type=TuyaBLEDataPointType.DT_BITMAP,
+                    bit=4,
+                    description=BinarySensorEntityDescription(
+                        key="motor_fault",
+                        name="Motor Fault",
+                        device_class=BinarySensorDeviceClass.PROBLEM,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLEBinarySensorMapping(
+                    dp_id=4,
+                    dp_type=TuyaBLEDataPointType.DT_BITMAP,
+                    bit=5,
+                    description=BinarySensorEntityDescription(
+                        key="low_temp",
+                        name="Low Temperature",
+                        device_class=BinarySensorDeviceClass.COLD,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+            ],
+        },
+    ),
     "jtmspro": TuyaBLECategoryBinarySensorMapping(
         products={
             "hs21i377": [
@@ -177,7 +259,13 @@ class TuyaBLEBinarySensor(TuyaBLEEntity, BinarySensorEntity):
         else:
             datapoint = self._device.datapoints[self._mapping.dp_id]
             if datapoint:
-                self._attr_is_on = bool(datapoint.value)
+                if self._mapping.bit is not None and datapoint.value is not None:
+                    value = datapoint.value
+                    if isinstance(value, bytes):
+                        value = value[0]
+                    self._attr_is_on = bool((value >> self._mapping.bit) & 1)
+                else:
+                    self._attr_is_on = bool(datapoint.value)
                 """
                 if datapoint.type == TuyaBLEDataPointType.DT_ENUM:
                     if self.entity_description.options is not None:

--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -34,6 +34,13 @@ TuyaBLEBinarySensorIsAvailable = (
 )
 
 
+def _bitmap_value_to_int(value: bytes | bytearray | int) -> int:
+    """Convert a Tuya bitmap datapoint value to an integer bitfield."""
+    if isinstance(value, bytes | bytearray):
+        return int.from_bytes(value, "big")
+    return int(value)
+
+
 @dataclass
 class TuyaBLEBinarySensorMapping:
     """Models a BLE binary sensor"""
@@ -260,9 +267,7 @@ class TuyaBLEBinarySensor(TuyaBLEEntity, BinarySensorEntity):
             datapoint = self._device.datapoints[self._mapping.dp_id]
             if datapoint:
                 if self._mapping.bit is not None and datapoint.value is not None:
-                    value = datapoint.value
-                    if isinstance(value, bytes):
-                        value = value[0]
+                    value = _bitmap_value_to_int(datapoint.value)
                     self._attr_is_on = bool((value >> self._mapping.bit) & 1)
                 else:
                     self._attr_is_on = bool(datapoint.value)

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -584,6 +584,9 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                     ),
                 ),
             ),
+            "ldcdnigc": TuyaBLEProductInfo(
+                name="ZX-7378 Smart Irrigation Controller",
+            ),
         },
     ),
     "ggq": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -668,6 +668,20 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     ),
                 ],
             ),
+            "ldcdnigc": [
+                TuyaBLENumberMapping(
+                    dp_id=11,
+                    description=NumberEntityDescription(
+                        key="countdown",
+                        icon="mdi:timer",
+                        native_max_value=86400,
+                        native_min_value=0,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        native_step=1,
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+            ],
             "svhikeyq": [
                 TuyaBLENumberMapping(
                     dp_id=11,

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -678,7 +678,6 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                         native_min_value=0,
                         native_unit_of_measurement=UnitOfTime.SECONDS,
                         native_step=1,
-                        entity_category=EntityCategory.CONFIG,
                     ),
                 ),
             ],

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1035,7 +1035,6 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                         key="work_state",
                         device_class=SensorDeviceClass.ENUM,
                         options=["auto", "manual", "idle"],
-                        entity_category=EntityCategory.DIAGNOSTIC,
                     ),
                 ),
                 TuyaBLESensorMapping(
@@ -1057,7 +1056,6 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                         name="Battery Percentage",
                         device_class=SensorDeviceClass.BATTERY,
                         native_unit_of_measurement=PERCENTAGE,
-                        entity_category=EntityCategory.DIAGNOSTIC,
                         state_class=SensorStateClass.MEASUREMENT,
                     ),
                 ),
@@ -1067,6 +1065,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                         key="use_time_one",
                         device_class=SensorDeviceClass.DURATION,
                         native_unit_of_measurement=UnitOfTime.SECONDS,
+                        entity_category=EntityCategory.DIAGNOSTIC,
                         state_class=SensorStateClass.MEASUREMENT,
                     ),
                 ),

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1027,6 +1027,50 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     ),
                 ),
             ],
+            "ldcdnigc": [  # ZX-7378 Smart Irrigation Controller
+                TuyaBLESensorMapping(
+                    dp_id=12,
+                    dp_type=TuyaBLEDataPointType.DT_ENUM,
+                    description=SensorEntityDescription(
+                        key="work_state",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=["auto", "manual", "idle"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=8,
+                    dp_type=TuyaBLEDataPointType.DT_ENUM,
+                    description=SensorEntityDescription(
+                        key="battery_state",
+                        name="Battery State",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=["low", "middle", "high"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=7,
+                    dp_type=TuyaBLEDataPointType.DT_VALUE,
+                    description=SensorEntityDescription(
+                        key="battery_percentage",
+                        name="Battery Percentage",
+                        device_class=SensorDeviceClass.BATTERY,
+                        native_unit_of_measurement=PERCENTAGE,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=15,
+                    description=SensorEntityDescription(
+                        key="use_time_one",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+            ],
             "hfgdqhho": [  # Irrigation computer - SGW02/SGW08
                 TuyaBLEBatteryMapping(dp_id=11),
                 TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -30,11 +30,26 @@
     },
     "entity": {
         "binary_sensor": {
+            "fault": {
+                "name": "Fault"
+            },
+            "lack_water": {
+                "name": "Lack of water"
+            },
             "low_battery": {
                 "name": "Battery"
             },
             "lock_motor_state": {
                 "name": "Motor State"
+            },
+            "low_temp": {
+                "name": "Low temperature"
+            },
+            "motor_fault": {
+                "name": "Motor fault"
+            },
+            "sensor_fault": {
+                "name": "Sensor fault"
             }
         },
         "button": {

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -179,6 +179,15 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     ),
                 ],
             ),
+            "ldcdnigc": [
+                TuyaBLESwitchMapping(
+                    dp_id=1,
+                    description=SwitchEntityDescription(
+                        key="water_valve",
+                        icon="mdi:valve",
+                    ),
+                ),
+            ],
             **dict.fromkeys(
                 ["nxquc5lb", "svhikeyq"],
                 [  # Smart water timer - SOP10

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -30,11 +30,26 @@
     },
     "entity": {
         "binary_sensor": {
+            "fault": {
+                "name": "Fault"
+            },
+            "lack_water": {
+                "name": "Lack of water"
+            },
             "low_battery": {
                 "name": "Battery"
             },
             "lock_motor_state": {
                 "name": "Motor State"
+            },
+            "low_temp": {
+                "name": "Low temperature"
+            },
+            "motor_fault": {
+                "name": "Motor fault"
+            },
+            "sensor_fault": {
+                "name": "Sensor fault"
             }
         },
         "button": {


### PR DESCRIPTION
# Add support to ZX-7378 Smart Irrigation Controller (product: ldcdnigc)

## Product specifications
```json
"model": "{\"modelId\":\"000004yeuw\",\"services\":[{\"actions\":[],\"code\":\"\",\"description\":\"\",\"events\":[],\"name\":\"默认服务\",\"properties\":[{\"abilityId\":1,\"accessMode\":\"rw\",\"code\":\"switch\",\"description\":\"\",\"extensions\":{\"iconName\":\"icon-dp_power2\",\"attribute\":\"1665\"},\"name\":\"灌溉控制\",\"typeSpec\":{\"type\":\"bool\"}},{\"abilityId\":4,\"accessMode\":\"ro\",\"code\":\"fault\",\"description\":\"\",\"extensions\":{\"iconName\":\"icon-baojing\",\"attribute\":\"1216\"},\"name\":\"故障上报\",\"typeSpec\":{\"type\":\"bitmap\",\"label\":[\"low_battery\",\"fault\",\"lack_water\",\"sensor_fault\",\"motor_fault\",\"low_temp\"],\"maxlen\":6}},{\"abilityId\":7,\"accessMode\":\"ro\",\"code\":\"battery_percentage\",\"description\":\"\",\"extensions\":{\"iconName\":\"icon-dp_battery\",\"attribute\":\"1216\"},\"name\":\"电池电量\",\"typeSpec\":{\"type\":\"value\",\"max\":100,\"min\":0,\"scale\":0,\"step\":1,\"unit\":\"%\"}},{\"abilityId\":8,\"accessMode\":\"ro\",\"code\":\"battery_state\",\"description\":\"\",\"extensions\":{\"iconName\":\"icon-dp_battery\",\"attribute\":\"1216\"},\"name\":\"电池状态\",\"typeSpec\":{\"type\":\"enum\",\"range\":[\"low\",\"middle\",\"high\"]}},{\"abilityId\":10,\"accessMode\":\"rw\",\"code\":\"weather_delay\",\"description\":\"\",\"extensions\":{\"iconName\":\"icon-dp_light2\",\"attribute\":\"1760\"},\"name\":\"天气延时\",\"typeSpec\":{\"type\":\"enum\",\"range\":[\"cancel\",\"24h\",\"48h\",\"72h\"]}},{\"abilityId\":11,\"accessMode\":\"rw\",\"code\":\"countdown\",\"description\":\"\",\"extensions\":{\"iconName\":\"icon-dp_time2\",\"attribute\":\"1728\"},\"name\":\"灌溉时长\",\"typeSpec\":{\"type\":\"value\",\"max\":86400,\"min\":0,\"scale\":0,\"step\":1,\"unit\":\"s\"}},{\"abilityId\":12,\"accessMode\":\"ro\",\"code\":\"work_state\",\"description\":\"\",\"extensions\":{\"iconName\":\"icon-zhuangtai\",\"attribute\":\"1248\"},\"name\":\"工作状态\",\"typeSpec\":{\"type\":\"enum\",\"range\":[\"auto\",\"manual\",\"idle\"]}},{\"abilityId\":15,\"accessMode\":\"ro\",\"code\":\"use_time_one\",\"description\":\"\",\"extensions\":{\"iconName\":\"icon-dp_time3\",\"attribute\":\"1216\"},\"name\":\"单次使用时间\",\"typeSpec\":{\"type\":\"value\",\"max\":86400,\"min\":0,\"scale\":0,\"step\":1,\"unit\":\"s\"}},{\"abilityId\":16,\"accessMode\":\"rw\",\"code\":\"cycle_timing\",\"description\":\"设置一段总的时间，在此时间段内可以设置开启时间段和关闭时间段，之后将以此时间循环开启和关闭。\\n循环定时主要用于解放劳动力，用于循环浇灌、投食、灯光场景控制等。\",\"extensions\":{\"iconName\":\"icon-dp_time3\",\"attribute\":\"1248\"},\"name\":\"周期灌溉\",\"typeSpec\":{\"type\":\"raw\",\"maxlen\":128}},{\"abilityId\":17,\"accessMode\":\"rw\",\"code\":\"timer\",\"description\":\"可按要求自定义时间完成阀门开启/关闭、以及灌溉时间，可自定义多组，支持周循环、奇偶日、隔天循环定时。\",\"extensions\":{\"iconName\":\"icon-timer1\",\"attribute\":\"1248\"},\"name\":\"普通定时\",\"typeSpec\":{\"type\":\"raw\",\"maxlen\":128}}]}]}"
```

## Missing
- Weather delay 
  > I have no use for it
- Day-to-day scheduler 
  > Technically feasible by reverse engineering the bits sent (I've done that), but while the command is correctly sent and stored into the device, nothing happens until you sync the device with the tuya mobile app.

## Known issues
- Lack of water fault indicator does not seem to be implemented by the manufacturor.
- Other fault indicators might be unusable too.

## Features
- Controls
  - Irigation duration (timer)
  - Valve switch
- Sensors
  - Battery percentage
  - Switch status
  - Work state (idle, auto or manual)
- Diagnostic
  - Fault: Battery --unsure if working
  - Battery state (low, middle, high)
  - Fault (general)
  - Fault : Lack of water -- not working 
   - Last irrigation time (real duration)
  - Fault : Low temperature -- unsure if working
  - Fault: Motor -- unsure if working
  - Signal strength 

## Dashboard
<img width="493" height="1673" alt="image" src="https://github.com/user-attachments/assets/e65a0202-7600-4bff-8a6c-d64894c38c6a" />

