### PR TITLE
Add support for Fingerbot Touch (bs3ubslo) and ADFBZ521 Fingerbot Plus (6jcvqwh0)

### DIFF
--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.entity import EntityCategory
 
-from .const import DOMAIN
+from .const import DOMAIN, FINGERBOT_MODE_CLICK
 from .devices import TuyaBLEData, TuyaBLEEntity, TuyaBLEProductInfo
 from .tuya_ble import TuyaBLEDataPointType, TuyaBLEDevice
 
@@ -46,6 +46,27 @@ def is_fingerbot_in_push_mode(self: TuyaBLEButton, product: TuyaBLEProductInfo) 
         if datapoint:
             result = datapoint.value == 0
     return result
+
+
+def is_fingerbot_touch_in_click_mode(
+    self: TuyaBLEButton, product: TuyaBLEProductInfo
+) -> bool:
+    """Button 1: available only if mode_1 (dp101) == 0 (click)"""
+    if product.fingerbot:
+        datapoint = self._device.datapoints[product.fingerbot.mode]
+        if datapoint:
+            return datapoint.value == 0
+    return False
+
+
+def is_fingerbot_touch_b2_in_click_mode(
+    self: TuyaBLEButton, product: TuyaBLEProductInfo
+) -> bool:
+    """Button 2: available only if mode_2 (dp102) == 0 (click)"""
+    datapoint = self._device.datapoints[102]
+    if datapoint:
+        return datapoint.value == 0
+    return False
 
 
 @dataclass
@@ -149,11 +170,29 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
     "kg": TuyaBLECategoryButtonMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotModeMapping(dp_id=108),
                 ],
             ),
+            "bs3ubslo": [  # Fingerbot Touch (dual button click triggers)
+                TuyaBLEButtonMapping(
+                    dp_id=1,
+                    description=ButtonEntityDescription(
+                        key="button_1_click",
+                        icon="mdi:gesture-tap",
+                    ),
+                    is_available=is_fingerbot_touch_in_click_mode,
+                ),
+                TuyaBLEButtonMapping(
+                    dp_id=2,
+                    description=ButtonEntityDescription(
+                        key="button_2_click",
+                        icon="mdi:gesture-tap",
+                    ),
+                    is_available=is_fingerbot_touch_b2_in_click_mode,
+                ),
+            ],
         },
     ),
     "znhsb": TuyaBLECategoryButtonMapping(

--- a/custom_components/tuya_ble/const.py
+++ b/custom_components/tuya_ble/const.py
@@ -67,6 +67,7 @@ CO2_LEVEL_NORMAL: Final = "normal"
 CO2_LEVEL_ALARM: Final = "alarm"
 
 FINGERBOT_MODE_PUSH: Final = "push"
+FINGERBOT_MODE_CLICK: Final = "click"
 FINGERBOT_MODE_SWITCH: Final = "switch"
 FINGERBOT_MODE_PROGRAM: Final = "program"
 FINGERBOT_BUTTON_EVENT: Final = "fingerbot_button_pressed"

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -488,7 +488,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
     "kg": TuyaBLECategoryInfo(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo"],  # device product_ids
+                ["mknd4lci", "riecov42", "6jcvqwh0"],  # device product_ids
                 TuyaBLEProductInfo(
                     name="Fingerbot Plus",
                     fingerbot=TuyaBLEFingerbotInfo(
@@ -501,6 +501,19 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                         manual_control=107,
                         program=109,
                     ),
+                ),
+            ),
+            "bs3ubslo": TuyaBLEProductInfo(
+                name="Fingerbot Touch",
+                fingerbot=TuyaBLEFingerbotInfo(
+                    switch=1,
+                    mode=101,
+                    up_position=0,
+                    down_position=0,
+                    hold_time=0,
+                    reverse_positions=0,
+                    manual_control=0,
+                    program=0,
                 ),
             ),
             "4ctjfrzq": TuyaBLEProductInfo(

--- a/custom_components/tuya_ble/light.py
+++ b/custom_components/tuya_ble/light.py
@@ -439,6 +439,9 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     ),
 }
 
+# Fingerbot Touch has no backlight entity
+ProductsMapping.setdefault("kg", {})["bs3ubslo"] = ()
+
 # Socket (duplicate of `kg`)
 # https://developer.tuya.com/en/docs/iot/s?id=K9gf7o5prgf7s
 LIGHTS["cz"] = LIGHTS["kg"]

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
+from .const import DOMAIN, FINGERBOT_MODE_PROGRAM
 from .devices import TuyaBLEData, TuyaBLEEntity, TuyaBLEProductInfo
 from .tuya_ble import TuyaBLEDataPointType, TuyaBLEDevice
 
@@ -468,7 +468,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
     "kg": TuyaBLECategoryNumberMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLENumberMapping(
                         dp_id=102,
@@ -512,6 +512,56 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     ),
                 ],
             ),
+            "bs3ubslo": [  # Fingerbot Touch (dual button touch timing)
+                TuyaBLENumberMapping(
+                    dp_id=103,
+                    description=NumberEntityDescription(
+                        key="touch_time_1",
+                        icon="mdi:timer",
+                        native_min_value=100,
+                        native_max_value=10000,
+                        native_step=100,
+                        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLENumberMapping(
+                    dp_id=117,
+                    description=NumberEntityDescription(
+                        key="off_touch_time_1",
+                        icon="mdi:timer-off",
+                        native_min_value=100,
+                        native_max_value=10000,
+                        native_step=100,
+                        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLENumberMapping(
+                    dp_id=104,
+                    description=NumberEntityDescription(
+                        key="touch_time_2",
+                        icon="mdi:timer",
+                        native_min_value=100,
+                        native_max_value=10000,
+                        native_step=100,
+                        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLENumberMapping(
+                    dp_id=118,
+                    description=NumberEntityDescription(
+                        key="off_touch_time_2",
+                        icon="mdi:timer-off",
+                        native_min_value=100,
+                        native_max_value=10000,
+                        native_step=100,
+                        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+            ],
         },
     ),
     "wk": TuyaBLECategoryNumberMapping(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     DOMAIN,
+    FINGERBOT_MODE_CLICK,
     FINGERBOT_MODE_PROGRAM,
     FINGERBOT_MODE_PUSH,
     FINGERBOT_MODE_SWITCH,
@@ -58,6 +59,23 @@ class TuyaBLEFingerbotModeMapping(TuyaBLESelectMapping):
             entity_category=EntityCategory.CONFIG,
             options=[
                 FINGERBOT_MODE_PUSH,
+                FINGERBOT_MODE_SWITCH,
+                FINGERBOT_MODE_PROGRAM,
+            ],
+        )
+    )
+
+
+@dataclass
+class TuyaBLEFingerbotTouchModeMapping(TuyaBLESelectMapping):
+    """Fingerbot Touch mode mapping (uses 'click' instead of 'push')"""
+
+    description: SelectEntityDescription = field(
+        default_factory=lambda: SelectEntityDescription(
+            key="fingerbot_mode",
+            entity_category=EntityCategory.CONFIG,
+            options=[
+                FINGERBOT_MODE_CLICK,
                 FINGERBOT_MODE_SWITCH,
                 FINGERBOT_MODE_PROGRAM,
             ],
@@ -372,11 +390,26 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
     "kg": TuyaBLECategorySelectMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotModeMapping(dp_id=101),
                 ],
             ),
+            "bs3ubslo": [  # Fingerbot Touch (dual button, mode = click/switch/program)
+                TuyaBLEFingerbotTouchModeMapping(dp_id=101),
+                TuyaBLEFingerbotTouchModeMapping(
+                    dp_id=102,
+                    description=SelectEntityDescription(
+                        key="fingerbot_mode_2",
+                        entity_category=EntityCategory.CONFIG,
+                        options=[
+                            FINGERBOT_MODE_CLICK,
+                            FINGERBOT_MODE_SWITCH,
+                            FINGERBOT_MODE_PROGRAM,
+                        ],
+                    ),
+                ),
+            ],
         },
     ),
     "wsdcg": TuyaBLECategorySelectMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -401,11 +401,28 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
     "kg": TuyaBLECategorySensorMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLEBatteryMapping(dp_id=105),
                 ],
             ),
+            "bs3ubslo": [  # Fingerbot Touch
+                TuyaBLEBatteryMapping(dp_id=115),
+                TuyaBLESensorMapping(
+                    dp_id=116,
+                    description=SensorEntityDescription(
+                        key="charge_status",
+                        device_class=SensorDeviceClass.ENUM,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        options=["none", "charging", "charge_done"],
+                    ),
+                    icons=[
+                        "mdi:power-plug-off",
+                        "mdi:battery-charging",
+                        "mdi:battery-check",
+                    ],
+                ),
+            ],
         },
     ),
     "wsdcg": TuyaBLECategorySensorMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -412,6 +412,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     dp_id=116,
                     description=SensorEntityDescription(
                         key="charge_status",
+                        entity_registry_enabled_default=False,
                         device_class=SensorDeviceClass.ENUM,
                         entity_category=EntityCategory.DIAGNOSTIC,
                         options=["none", "charging", "charge_done"],

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
+from .const import DOMAIN, FINGERBOT_MODE_CLICK, FINGERBOT_MODE_SWITCH, FINGERBOT_MODE_PROGRAM
 from .devices import TuyaBLEData, TuyaBLEEntity, TuyaBLEProductInfo
 from .tuya_ble import TuyaBLEDataPointType, TuyaBLEDevice
 
@@ -70,6 +70,48 @@ def is_fingerbot_in_switch_mode(
         if datapoint:
             result = datapoint.value == 1
     return result
+
+
+def is_fingerbot_touch_in_switch_mode(
+    self: TuyaBLESwitch, product: TuyaBLEProductInfo
+) -> bool:
+    """Button 1: mode_1 (dp101) == 1 (switch)"""
+    if product.fingerbot:
+        datapoint = self._device.datapoints[product.fingerbot.mode]
+        if datapoint:
+            return datapoint.value == 1
+    return True
+
+
+def is_fingerbot_touch_in_program_mode(
+    self: TuyaBLESwitch, product: TuyaBLEProductInfo
+) -> bool:
+    """Button 1: mode_1 (dp101) == 2 (program)"""
+    if product.fingerbot:
+        datapoint = self._device.datapoints[product.fingerbot.mode]
+        if datapoint:
+            return datapoint.value == 2
+    return False
+
+
+def is_fingerbot_touch_b2_in_switch_mode(
+    self: TuyaBLESwitch, product: TuyaBLEProductInfo
+) -> bool:
+    """Button 2: mode_2 (dp102) == 1 (switch)"""
+    datapoint = self._device.datapoints[102]
+    if datapoint:
+        return datapoint.value == 1
+    return True
+
+
+def is_fingerbot_touch_b2_in_program_mode(
+    self: TuyaBLESwitch, product: TuyaBLEProductInfo
+) -> bool:
+    """Button 2: mode_2 (dp102) == 2 (program)"""
+    datapoint = self._device.datapoints[102]
+    if datapoint:
+        return datapoint.value == 2
+    return False
 
 
 def is_water_valve_in_switch_mode(
@@ -316,7 +358,7 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
     "kg": TuyaBLECategorySwitchMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotSwitchMapping(dp_id=1),
                     TuyaBLEReversePositionsMapping(dp_id=104),
@@ -349,6 +391,66 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     ),
                 ],
             ),
+            "bs3ubslo": [  # Fingerbot Touch (dual button)
+                TuyaBLESwitchMapping(
+                    dp_id=1,
+                    description=SwitchEntityDescription(key="switch"),
+                    is_available=is_fingerbot_touch_in_switch_mode,
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=1,
+                    description=SwitchEntityDescription(
+                        key="program", icon="mdi:repeat"
+                    ),
+                    is_available=is_fingerbot_touch_in_program_mode,
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=2,
+                    description=SwitchEntityDescription(
+                        key="switch_2", icon="mdi:gesture-tap"
+                    ),
+                    is_available=is_fingerbot_touch_b2_in_switch_mode,
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=2,
+                    description=SwitchEntityDescription(
+                        key="program_2", icon="mdi:repeat"
+                    ),
+                    is_available=is_fingerbot_touch_b2_in_program_mode,
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=105,
+                    description=SwitchEntityDescription(
+                        key="touch_enable_1",
+                        icon="mdi:gesture-tap-button",
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=106,
+                    description=SwitchEntityDescription(
+                        key="touch_enable_2",
+                        icon="mdi:gesture-tap-button",
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=107,
+                    description=SwitchEntityDescription(
+                        key="invert_switch_1",
+                        icon="mdi:swap-horizontal",
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=108,
+                    description=SwitchEntityDescription(
+                        key="invert_switch_2",
+                        icon="mdi:swap-horizontal",
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+            ],
             "4ctjfrzq": [
                 TuyaBLESwitchMapping(
                     dp_id=1,


### PR DESCRIPTION
## Summary

- **Fingerbot Touch (bs3ubslo)**: full dual-button support with per-button mode (click/switch/program), touch timing, touch enable, invert, battery and charge status
- **ADFBZ521 Fingerbot Plus (6jcvqwh0)**: moved from `sjj` basic switch to `kg` fingerbot category for complete fingerbot support

## Changes by file

| File | Change |
|------|--------|
| `const.py` | Added `FINGERBOT_MODE_CLICK = "click"` between push and switch |
| `devices.py` | Added `6jcvqwh0` to Fingerbot Plus group; new standalone `bs3ubslo` entry with dual-button fingerbot config |
| `button.py` | Click-mode buttons (dp1, dp2) with per-button `is_available` guards |
| `select.py` | `TuyaBLEFingerbotTouchModeMapping` for mode dp101/dp102 (click/switch/program) |
| `switch.py` | Per-button switch/program/touch_enable/invert entities with mode guards |
| `number.py` | Touch timing: touch_time and off_touch_time for each button (dp103/104/117/118) |
| `sensor.py` | Battery (dp115) and charge_status (dp116, disabled by default) for bs3ubslo; added `6jcvqwh0` to Fingerbot Plus battery group |
| `light.py` | Suppress backlight entity for bs3ubslo |

## Notes on charge_status (dp116)

dp116 is event-driven: the device only reports it when a charger is connected. When not charging, HA would show `unknown`. The entity is disabled by default; users can enable it manually to monitor charging state.

## Test plan

- [x] Fingerbot Touch (bs3ubslo) — button_1_click and button_2_click work in HA; mode select, touch timing, touch enable, invert updated correctly via ESPHome BLE proxy
- [x] ADFBZ521 Fingerbot Plus (6jcvqwh0) — full fingerbot entities now available
- [x] Existing Fingerbot Plus products (mknd4lci, riecov42) — not affected
