### PR TITLE
Add support and enhancements for Aldi Gardenline (16wgjvck) water valve mappings. And added support for Atomic Multi-Datapoint Payloads (simultaneous DP dispatch).

### DIFF
--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -539,6 +539,16 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
     ),
     "sfkzq": TuyaBLECategoryInfo(
         products={
+            "16wgjvck": TuyaBLEProductInfo(
+                name="Aldi/Ferrex Smart Water Valve",
+                watervalve=TuyaBLEWaterValveInfo(
+                    switch=1,
+                    countdown=11,
+                    weather_delay=10,
+                    smart_weather=13,
+                    use_time=15,
+                ),
+            ),
             **dict.fromkeys(
                 [
                     "6pahkcau",

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -652,6 +652,41 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
     ),
     "sfkzq": TuyaBLECategoryNumberMapping(
         products={
+            "16wgjvck": [
+                TuyaBLENumberMapping(
+                    dp_id=2,
+                    description=NumberEntityDescription(
+                        key="valve_opening_percentage",
+                        icon="mdi:valve",
+                        native_max_value=100,
+                        native_min_value=0,
+                        native_unit_of_measurement=PERCENTAGE,
+                        native_step=1,
+                    ),
+                ),
+                TuyaBLENumberMapping(
+                    dp_id=11,
+                    description=NumberEntityDescription(
+                        key="countdown",
+                        icon="mdi:timer",
+                        native_max_value=86400,
+                        native_min_value=0,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        native_step=1,
+                    ),
+                ),
+                TuyaBLENumberMapping(
+                    dp_id=15,
+                    description=NumberEntityDescription(
+                        key="use_time",
+                        icon="mdi:timer",
+                        native_max_value=86400,
+                        native_min_value=0,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        native_step=1,
+                    ),
+                ),
+            ],
             **dict.fromkeys(
                 ["46zia2nz", "1fcnd8xk", "0axr5s0b"],
                 [

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -122,6 +122,16 @@ class TuyaBLETemperatureUnitMapping(TuyaBLESelectMapping):
 mapping: dict[str, TuyaBLECategorySelectMapping] = {
     "sfkzq": TuyaBLECategorySelectMapping(
         products={
+            "16wgjvck": [
+                TuyaBLESelectMapping(
+                    dp_id=12,
+                    description=SelectEntityDescription(
+                        key="work_state",
+                        options=["auto", "manual"],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+            ],
             **dict.fromkeys(
                 ["46zia2nz", "1fcnd8xk", "0axr5s0b"],
                 [

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1017,12 +1017,37 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
             "16wgjvck": [
                 TuyaBLEBatteryMapping(dp_id=7),
                 TuyaBLESensorMapping(
+                    dp_id=7,
+                    dp_type=TuyaBLEDataPointType.DT_VALUE,
+                    description=SensorEntityDescription(
+                        key="battery_percentage",
+                        name="Battery Percentage",
+                        device_class=SensorDeviceClass.BATTERY,
+                        native_unit_of_measurement=PERCENTAGE,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
                     dp_id=8,
                     dp_type=TuyaBLEDataPointType.DT_ENUM,
                     description=SensorEntityDescription(
                         key="battery_state",
+                        name="Battery State",
                         device_class=SensorDeviceClass.ENUM,
                         options=["low", "middle", "high"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=104,
+                    dp_type=TuyaBLEDataPointType.DT_VALUE,
+                    description=SensorEntityDescription(
+                        key="battery_percentage_alt",
+                        name="Battery Percentage (Alt)",
+                        device_class=SensorDeviceClass.BATTERY,
+                        native_unit_of_measurement=PERCENTAGE,
+                        state_class=SensorStateClass.MEASUREMENT,
                         entity_category=EntityCategory.DIAGNOSTIC,
                     ),
                 ),

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1014,6 +1014,19 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
     ),
     "sfkzq": TuyaBLECategorySensorMapping(
         products={
+            "16wgjvck": [
+                TuyaBLEBatteryMapping(dp_id=7),
+                TuyaBLESensorMapping(
+                    dp_id=8,
+                    dp_type=TuyaBLEDataPointType.DT_ENUM,
+                    description=SensorEntityDescription(
+                        key="battery_state",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=["low", "middle", "high"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+            ],
             "0axr5s0b": [  # Valve Controller
                 TuyaBLEBatteryMapping(dp_id=7),
                 TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -130,8 +130,12 @@ def set_16wgjvck_water_valve(
         # Erstelle die Datenpunkte im Cache, FALLS sie noch nicht vom Gerät gesendet wurden,
         # damit "set_multiple_values" sie nicht einfach ignoriert.
         self._device.datapoints.get_or_create(1, TuyaBLEDataPointType.DT_BOOL, True)
-        self._device.datapoints.get_or_create(2, TuyaBLEDataPointType.DT_VALUE, dp_2_val)
-        self._device.datapoints.get_or_create(11, TuyaBLEDataPointType.DT_VALUE, dp_11_val)
+        self._device.datapoints.get_or_create(
+            2, TuyaBLEDataPointType.DT_VALUE, dp_2_val
+        )
+        self._device.datapoints.get_or_create(
+            11, TuyaBLEDataPointType.DT_VALUE, dp_11_val
+        )
 
         # Atomic Multi-Datapoint Payload for turning on
         dp_updates = {

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -129,6 +129,12 @@ def set_16wgjvck_water_valve(
         if dp_2_val <= 0:
             dp_2_val = 100
 
+        # Erstelle die Datenpunkte im Cache, FALLS sie noch nicht vom Gerät gesendet wurden,
+        # damit "set_multiple_values" sie nicht einfach ignoriert.
+        self._device.datapoints.get_or_create(1, TuyaBLEDataPointType.DT_BOOL, True)
+        self._device.datapoints.get_or_create(2, TuyaBLEDataPointType.DT_VALUE, dp_2_val)
+        self._device.datapoints.get_or_create(11, TuyaBLEDataPointType.DT_VALUE, dp_11_val)
+
         # Atomic Multi-Datapoint Payload for turning on
         dp_updates = {
             1: True,
@@ -138,6 +144,7 @@ def set_16wgjvck_water_valve(
         self._hass.create_task(self._device.set_multiple_values(dp_updates))
     else:
         # Just turn off the switch
+        self._device.datapoints.get_or_create(1, TuyaBLEDataPointType.DT_BOOL, False)
         self._hass.create_task(self._device.set_multiple_values({1: False}))
 
 @dataclass

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -104,6 +104,7 @@ def set_fingerbot_program_repeat_forever(
             )
             self._hass.create_task(datapoint.set_value(new_value))
 
+
 def set_16wgjvck_water_valve(
     self: TuyaBLESwitch, product: TuyaBLEProductInfo, value: bool
 ) -> None:
@@ -112,15 +113,12 @@ def set_16wgjvck_water_valve(
         dp_11_val = 60
         dp15 = self._device.datapoints[15]
         dp11 = self._device.datapoints[11]
-        
         if dp15 and dp15.value:
             dp_11_val = int(dp15.value)
         elif dp11 and dp11.value:
             dp_11_val = int(dp11.value)
-            
         if dp_11_val <= 0:
             dp_11_val = 60
-            
         # Lese die eingestellte Ventilöffnung (DP 2)
         dp_2_val = 100
         dp2 = self._device.datapoints[2]
@@ -146,6 +144,7 @@ def set_16wgjvck_water_valve(
         # Just turn off the switch
         self._device.datapoints.get_or_create(1, TuyaBLEDataPointType.DT_BOOL, False)
         self._hass.create_task(self._device.set_multiple_values({1: False}))
+
 
 @dataclass
 class TuyaBLEFingerbotSwitchMapping(TuyaBLESwitchMapping):

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -104,6 +104,23 @@ def set_fingerbot_program_repeat_forever(
             )
             self._hass.create_task(datapoint.set_value(new_value))
 
+def set_16wgjvck_water_valve(
+    self: TuyaBLESwitch, product: TuyaBLEProductInfo, value: bool
+) -> None:
+    if value:
+        # Atomic Multi-Datapoint Payload for turning on
+        # DP 1: True (Switch)
+        # DP 2: 100% (Valve opening)
+        # DP 11: 60s (Countdown time left)
+        dp_updates = {
+            1: True,
+            2: 100,
+            11: 60,
+        }
+        self._hass.create_task(self._device.set_multiple_values(dp_updates))
+    else:
+        # Just turn off the switch
+        self._hass.create_task(self._device.set_multiple_values({1: False}))
 
 @dataclass
 class TuyaBLEFingerbotSwitchMapping(TuyaBLESwitchMapping):
@@ -186,6 +203,16 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                         key="water_valve",
                         icon="mdi:valve",
                     ),
+                ),
+            ],
+            "16wgjvck": [  # Aldi/Ferrex Smart Water Valve
+                TuyaBLESwitchMapping(
+                    dp_id=1,
+                    description=SwitchEntityDescription(
+                        key="water_valve",
+                        icon="mdi:valve",
+                    ),
+                    setter=set_16wgjvck_water_valve,
                 ),
             ],
             **dict.fromkeys(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -108,14 +108,32 @@ def set_16wgjvck_water_valve(
     self: TuyaBLESwitch, product: TuyaBLEProductInfo, value: bool
 ) -> None:
     if value:
+        # Lese vorher den eingestellten Timer (DP 15 = use_time oder DP 11 = countdown)
+        dp_11_val = 60
+        dp15 = self._device.datapoints[15]
+        dp11 = self._device.datapoints[11]
+        
+        if dp15 and dp15.value:
+            dp_11_val = int(dp15.value)
+        elif dp11 and dp11.value:
+            dp_11_val = int(dp11.value)
+            
+        if dp_11_val <= 0:
+            dp_11_val = 60
+            
+        # Lese die eingestellte Ventilöffnung (DP 2)
+        dp_2_val = 100
+        dp2 = self._device.datapoints[2]
+        if dp2 and dp2.value is not None:
+            dp_2_val = int(dp2.value)
+        if dp_2_val <= 0:
+            dp_2_val = 100
+
         # Atomic Multi-Datapoint Payload for turning on
-        # DP 1: True (Switch)
-        # DP 2: 100% (Valve opening)
-        # DP 11: 60s (Countdown time left)
         dp_updates = {
             1: True,
-            2: 100,
-            11: 60,
+            2: dp_2_val,
+            11: dp_11_val,
         }
         self._hass.create_task(self._device.set_multiple_values(dp_updates))
     else:

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -1467,3 +1467,40 @@ class TuyaBLEDevice:
             await self._send_datapoints_v3(datapoint_ids)
         else:
             raise TuyaBLEDeviceError(0)
+
+    async def set_multiple_values(self, dp_updates: dict[int, Any]) -> None:
+        """Set multiple datapoint values in a single atomic BLE payload."""
+        data = bytearray()
+        updated_dps = []
+        
+        for dp_id, value in dp_updates.items():
+            dp = self._datapoints[dp_id]
+            if not dp:
+                continue
+
+            # Update the internal state safely
+            if dp.type in [TuyaBLEDataPointType.DT_RAW, TuyaBLEDataPointType.DT_BITMAP]:
+                dp._value = bytes(value)
+            elif dp.type == TuyaBLEDataPointType.DT_BOOL:
+                dp._value = bool(value)
+            elif dp.type == TuyaBLEDataPointType.DT_VALUE:
+                dp._value = int(value)
+            elif dp.type == TuyaBLEDataPointType.DT_ENUM:
+                dp._value = int(value)
+            elif dp.type == TuyaBLEDataPointType.DT_STRING:
+                dp._value = str(value)
+            
+            dp._changed_by_device = False
+            updated_dps.append(dp)
+
+            # Build the payload according to protocol version 3
+            val_bytes = dp._get_value()
+            data += pack(">BBB", dp.id, int(dp.type.value), len(val_bytes))
+            data += val_bytes
+
+        if not data:
+            return
+            
+        await self._send_packet(TuyaBLECode.FUN_SENDER_DPS, data)
+        self._fire_callbacks(updated_dps)
+

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -1500,4 +1500,3 @@ class TuyaBLEDevice:
             return
         await self._send_packet(TuyaBLECode.FUN_SENDER_DPS, data)
         self._fire_callbacks(updated_dps)
-

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -1472,7 +1472,6 @@ class TuyaBLEDevice:
         """Set multiple datapoint values in a single atomic BLE payload."""
         data = bytearray()
         updated_dps = []
-        
         for dp_id, value in dp_updates.items():
             dp = self._datapoints[dp_id]
             if not dp:
@@ -1489,7 +1488,6 @@ class TuyaBLEDevice:
                 dp._value = int(value)
             elif dp.type == TuyaBLEDataPointType.DT_STRING:
                 dp._value = str(value)
-            
             dp._changed_by_device = False
             updated_dps.append(dp)
 
@@ -1500,7 +1498,6 @@ class TuyaBLEDevice:
 
         if not data:
             return
-            
         await self._send_packet(TuyaBLECode.FUN_SENDER_DPS, data)
         self._fire_callbacks(updated_dps)
 


### PR DESCRIPTION
This pull request adds comprehensive support for the Aldi/Gardenline/Ferrex Smart Water Valve (`16wgjvck` product) in the Tuya BLE integration. The changes include device definition, switch, number, select, and sensor entity mappings, as well as a custom switch setter and a new method for atomic multi-datapoint updates.

**Device support and entity mapping:**

* Added `16wgjvck` (Aldi/Ferrex Smart Water Valve) to `TuyaBLECategoryInfo` with appropriate water valve datapoint mappings.
* Added switch entity mapping for `16wgjvck`, including a custom setter (`set_16wgjvck_water_valve`) to handle multi-datapoint updates when toggling the valve. [[1]](diffhunk://#diff-e835435dff198dc7f3ca3c2f76a3d672cf88c969bc31d789afb0f2d594949665R233-R242) [[2]](diffhunk://#diff-e835435dff198dc7f3ca3c2f76a3d672cf88c969bc31d789afb0f2d594949665R107-R148)
* Added number entity mappings for valve opening percentage, countdown, and use time for `16wgjvck`.
* Added select entity mapping for work state (auto/manual) for `16wgjvck`.
* Added sensor entity mappings for battery percentage, battery state, and alternate battery percentage for `16wgjvck`.

**Core functionality:**

* Introduced `set_multiple_values` method in `TuyaBLEDevice` to allow atomic updates of multiple datapoints in a single BLE payload, used by the new water valve setter.