### PR TITLE
Fix 'Device is not registered in Tuya cloud' when factory-infos returns colon-separated MACs

### DIFF
--- a/custom_components/tuya_ble/cloud.py
+++ b/custom_components/tuya_ble/cloud.py
@@ -185,10 +185,14 @@ class HASSTuyaBLEDeviceManager(AbstaractTuyaBLEDeviceManager):
                     if fi_response_result and len(fi_response_result) > 0:
                         factory_info = fi_response_result[0]
                         if factory_info and (TUYA_FACTORY_INFO_MAC in factory_info):
-                            mac = ":".join(
-                                factory_info[TUYA_FACTORY_INFO_MAC][i : i + 2]
-                                for i in range(0, 12, 2)
-                            ).upper()
+                            raw_mac = factory_info[TUYA_FACTORY_INFO_MAC]
+                            if ":" in raw_mac:
+                                # API already returned a colon-separated MAC
+                                mac = raw_mac.upper()
+                            else:
+                                mac = ":".join(
+                                    raw_mac[i : i + 2] for i in range(0, 12, 2)
+                                ).upper()
                             item.credentials[mac] = {
                                 CONF_ADDRESS: mac,
                                 CONF_UUID: device.get("uuid"),


### PR DESCRIPTION
## Problem

Setting up a device always failed with **"Device is not registered in Tuya cloud"**, even though:
- the device was paired in the Tuya Smart app,
- it was visible under the IoT project (Link App Account),
- login succeeded (correct Access ID/Secret),
- the BLE discovery MAC matched the MAC shown by the Tuya cloud exactly.

Same symptom as #150.

## Root cause

`cloud.py::_fill_cache_item()` assumes `factory-infos` returns the MAC as a bare hex string (`dc2350debd04`) and re-inserts colons every two characters. The `/v1.0/iot-03/devices/factory-infos` endpoint (verified on the Central Europe data center via the IoT Platform API Explorer) returns the MAC **already colon-separated**:

```json
{ "id": "bf1a12kclajpergm", "mac": "DC:23:50:DE:BD:04", ... }
```

Slicing that string every 2 chars produces a mangled cache key (`"DC::2:3::5..."`), so the lookup by BLE discovery address can never match and every pairing attempt ends in `device_not_registered`.

## Fix

Detect the format: if the returned MAC already contains `:`, just uppercase it; otherwise keep the existing bare-hex handling.

## Testing

Verified on real hardware:
- SGS01 soil moisture sensor (category `zwjcy`, product `gvygg3m8`)
- HA 2026.7.1, integration installed via HACS, Central Europe DC
- Before: every attempt → "Device is not registered in Tuya cloud"
- After: device pairs and reports humidity/temperature/battery over BLE

Note: this PR is AI-assisted (diagnosed and patched with Claude Code on a live Home Assistant instance, then verified end-to-end).