### PR TITLE
Add support for RESTMO BT Water Meter (FML026A)

### DIFF
--- a/custom_components/tuya_ble/const.py
+++ b/custom_components/tuya_ble/const.py
@@ -427,6 +427,8 @@ class DPCode(StrEnum):
     CUR_CURRENT = "cur_current"  # Actual current
     CUR_POWER = "cur_power"  # Actual power
     CUR_VOLTAGE = "cur_voltage"  # Actual voltage
+    DAY_USAGE_AFTER_RESET = "day_usage_after_reset"
+    DAY_WATER_USAGE = "day_water_usage"
     DECIBEL_SENSITIVITY = "decibel_sensitivity"
     DECIBEL_SWITCH = "decibel_switch"
     DEHUMIDITY_SET_ENUM = "dehumidify_set_enum"
@@ -460,6 +462,7 @@ class DPCode(StrEnum):
     FILTER_RESET = "filter_reset"  # Filter (cartridge) reset
     FLOODLIGHT_LIGHTNESS = "floodlight_lightness"
     FLOODLIGHT_SWITCH = "floodlight_switch"
+    FLOW_VELOCITY = "flow_velocity"
     FORWARD_ENERGY_TOTAL = "forward_energy_total"
     GAS_SENSOR_STATE = "gas_sensor_state"
     GAS_SENSOR_STATUS = "gas_sensor_status"
@@ -604,6 +607,7 @@ class DPCode(StrEnum):
     TOTAL_CLEAN_TIME = "total_clean_time"
     TOTAL_FORWARD_ENERGY = "total_forward_energy"
     TOTAL_TIME = "total_time"
+    TOTAL_USAGE_AFTER_RESET = "total_usage_after_reset"
     TOTAL_PM = "total_pm"
     TVOC = "tvoc"
     UNLOCK_BLE = "unlock_ble"
@@ -618,11 +622,14 @@ class DPCode(StrEnum):
     VOICE_SWITCH = "voice_switch"
     VOICE_TIMES = "voice_times"
     VOLUME_SET = "volume_set"
+    VOLTAGE_CURRENT = "voltage_current"
     WARM = "warm"  # Heat preservation
     WARM_TIME = "warm_time"  # Heat preservation time
     WATER = "water"
+    WATER_ONCE = "water_once"
     WATER_RESET = "water_reset"  # Resetting of water usage days
     WATER_SET = "water_set"  # Water level
+    WATER_USE_DATA = "water_use_data"
     WATERSENSOR_STATE = "watersensor_state"
     WEATHER_DELAY = "weather_delay"
     WET = "wet"  # Humidification

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -635,6 +635,13 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             ),
         },
     ),
+    "slj": TuyaBLECategoryInfo(
+        products={
+            "mqqna0px": TuyaBLEProductInfo(
+                name="RESTMO BT Water Meter",
+            ),
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1129,6 +1129,78 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
             ),
         }
     ),
+    "slj": TuyaBLECategorySensorMapping(
+        products={
+            "mqqna0px": [
+                TuyaBLEBatteryMapping(dp_id=4),
+                TuyaBLESensorMapping(
+                    dp_id=5,
+                    description=SensorEntityDescription(
+                        key="flow_velocity",
+                        icon="mdi:water-pump",
+                        native_unit_of_measurement="L/min",
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                    coefficient=10.0,
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=2,
+                    description=SensorEntityDescription(
+                        key="water_once",
+                        icon="mdi:water",
+                        native_unit_of_measurement=UnitOfVolume.LITERS,
+                        device_class=SensorDeviceClass.WATER,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    coefficient=10.0,
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=1,
+                    description=SensorEntityDescription(
+                        key="water_use_data",
+                        icon="mdi:water",
+                        native_unit_of_measurement=UnitOfVolume.LITERS,
+                        device_class=SensorDeviceClass.WATER,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    coefficient=10.0,
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=101,
+                    description=SensorEntityDescription(
+                        key="day_water_usage",
+                        icon="mdi:water",
+                        native_unit_of_measurement=UnitOfVolume.LITERS,
+                        device_class=SensorDeviceClass.WATER,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    coefficient=10.0,
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=107,
+                    description=SensorEntityDescription(
+                        key="total_usage_after_reset",
+                        icon="mdi:water",
+                        native_unit_of_measurement=UnitOfVolume.LITERS,
+                        device_class=SensorDeviceClass.WATER,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    coefficient=10.0,
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=108,
+                    description=SensorEntityDescription(
+                        key="day_usage_after_reset",
+                        icon="mdi:water",
+                        native_unit_of_measurement=UnitOfVolume.LITERS,
+                        device_class=SensorDeviceClass.WATER,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    coefficient=10.0,
+                ),
+            ]
+        }
+    ),
 }
 
 

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -172,6 +172,15 @@
                     "normal": "Normal"
                 }
             },
+            "day_usage_after_reset": {
+                "name": "Daily usage after reset"
+            },
+            "day_water_usage": {
+                "name": "Daily water usage"
+            },
+            "flow_velocity": {
+                "name": "Flow rate"
+            },
             "humidity": {
                 "name": "Humidity"
             },
@@ -196,6 +205,9 @@
             "time_left": {
                 "name": "Remaining irrigation time"
             },
+            "total_usage_after_reset": {
+                "name": "Total usage after reset"
+            },
             "use_time_z1": {
                 "name": "Last irrigation time - Zone 1"
             },
@@ -210,6 +222,12 @@
             },
             "water_intake": {
                 "name": "Water intake"
+            },
+            "water_once": {
+                "name": "Last session water usage"
+            },
+            "water_use_data": {
+                "name": "Total water usage"
             },
             "wrong_finger": {
                 "name": "Wrong Fingerprint"

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -172,6 +172,15 @@
                     "normal": "Normal"
                 }
             },
+            "day_usage_after_reset": {
+                "name": "Daily usage after reset"
+            },
+            "day_water_usage": {
+                "name": "Daily water usage"
+            },
+            "flow_velocity": {
+                "name": "Flow rate"
+            },
             "lock_door_status": {
                 "name": "Door status",
                 "state": {
@@ -204,6 +213,9 @@
             "time_left": {
                 "name": "Remaining irrigation time"
             },
+            "total_usage_after_reset": {
+                "name": "Total usage after reset"
+            },
             "use_time_z1": {
                 "name": "Last irrigation time - Zone 1"
             },
@@ -218,6 +230,12 @@
             },
             "water_intake": {
                 "name": "Water intake"
+            },
+            "water_once": {
+                "name": "Last session water usage"
+            },
+            "water_use_data": {
+                "name": "Total water usage"
             },
             "wrong_finger": {
                 "name": "Wrong Fingerprint"


### PR DESCRIPTION
This PR adds support for the RESTMO BT Water Meter (FML026A) under the product category `slj` and Product ID `mqqna0px`.

It registers the device database mapping and configures entities in `sensor.py` for:
- Flow rate (`flow_velocity`)
- Battery level (`voltage_current`)
- Single session water usage (`water_once`)
- Total cumulative water usage (`water_use_data`)
- Daily water usage (`day_water_usage`)
- Reset accumulation tracking (`total_usage_after_reset` and `day_usage_after_reset`)

It also configures the corresponding translation keys in `strings.json` and `en.json`.