### PR TITLE
Fix Tuya BLE connection / notification packet handling issue after reconnect

### DIFF
--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -643,6 +643,7 @@ class TuyaBLEDevice:
         """Disconnected callback."""
         was_paired = self._is_paired
         self._is_paired = False
+        self._clean_input()
         if self._expected_disconnect:
             _LOGGER.debug(
                 "%s: Disconnected from device; RSSI: %s",
@@ -686,6 +687,7 @@ class TuyaBLEDevice:
             if client and client.is_connected:
                 await client.stop_notify(CHARACTERISTIC_NOTIFY)
                 await client.disconnect()
+        self._clean_input()
         async with self._seq_num_lock:
             self._current_seq_num = 1
 
@@ -1395,6 +1397,14 @@ class TuyaBLEDevice:
         packet_num, pos = self._unpack_int(data, pos)
 
         if packet_num < self._input_expected_packet_num:
+            if packet_num != 0:
+                _LOGGER.warning(
+                    "%s: Unexpected packet (number %s) in notifications, expected %s. Ignoring.",
+                    self.address,
+                    packet_num,
+                    self._input_expected_packet_num,
+                )
+                return
             _LOGGER.error(
                 "%s: Unexpected packet (number %s) in notifications, " "expected %s",
                 self.address,


### PR DESCRIPTION
This PR addresses the issue where Tuya BLE devices (specifically Fingerbots) stop responding after an unexpected disconnection and reconnection due to mismatched notification packet sequences.

1. **Root cause prevention**: We call `self._clean_input()` during disconnections (`_disconnected` callback and `_execute_disconnect`). This ensures all state buffers and packet counters are fully reset when a connection is severed, preventing any mismatch when the device restarts its packet index from 0 on reconnect.
2. **Self-Healing/Recovery**: In the packet notification handler, we handle duplicate or unexpected older packets (`packet_num < expected`) intelligently. If `packet_num != 0` (e.g. late duplicate), it is ignored and dropped. If `packet_num == 0` (indicating sender started a new message), the receiver resets corrupt state and processes packet 0 immediately.

---
*PR created automatically by Jules for task [3654045266996252504](https://jules.google.com/task/3654045266996252504) started by @CloCkWeRX*