### PR TITLE
Add support for Lock P1 (product_id 7a4xvbtt) via @jpmreis

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The integration works locally, but connection to Tuya BLE device requires device
   + CO2 Detector (product_id '59s19z5m').
 
 * Smart Locks (category_id 'ms', 'jtmspro')
-  + Smart Lock (product_id 'ludzroix', 'isk2p555', 'gumrixyt', 'sidhzylo', 'mqc2hevy').
+  + Smart Lock (product_ids 'ludzroix', 'isk2p555', 'gumrixyt', 'sidhzylo', 'mqc2hevy', '7a4xvbtt').
   + Raybuke K7 Pro+ (product_id 'xicdxood'), supports ble unlock and other small features.
   + Fingerprint Smart Lock (product_id 'k53ok3u9')
   + T55D: Battery & Door status (product_id 'bvclwu9b')

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -358,6 +358,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                     "sidhzylo",
                     "mqc2hevy",
                     "a6nttc41",
+                    "7a4xvbtt",
                 ],
                 TuyaBLEProductInfo(  # device product_id
                     name="Smart Lock",

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -222,6 +222,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                     "uamrw6h3",
                     "okkyfgfs",
                     "sidhzylo",
+                    "7a4xvbtt",
                 ],  # Smart Lock
                 [
                     TuyaBLESelectMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -199,6 +199,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     "sidhzylo",
                     "bvclwu9b",
                     "k53ok3u9",
+                    "7a4xvbtt",
                 ],  # Smart Lock
                 [
                     TuyaBLEAlarmLockStateMapping(dp_id=21),

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -234,7 +234,13 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
     "ms": TuyaBLECategorySwitchMapping(
         products={
             **dict.fromkeys(
-                ["ludzroix", "isk2p555", "gumrixyt", "sidhzylo", "7a4xvbtt"],  # Smart Lock
+                [
+                    "ludzroix",
+                    "isk2p555",
+                    "gumrixyt",
+                    "sidhzylo",
+                    "7a4xvbtt",
+                ],  # Smart Lock
                 [TuyaLockMotorStateMapping(dp_id=47)],
             ),
             **dict.fromkeys(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -234,7 +234,7 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
     "ms": TuyaBLECategorySwitchMapping(
         products={
             **dict.fromkeys(
-                ["ludzroix", "isk2p555", "gumrixyt", "sidhzylo"],  # Smart Lock
+                ["ludzroix", "isk2p555", "gumrixyt", "sidhzylo", "7a4xvbtt"],  # Smart Lock
                 [TuyaLockMotorStateMapping(dp_id=47)],
             ),
             **dict.fromkeys(


### PR DESCRIPTION
Cherry-picked and adapted jpmreis's support for Lock P1 (product_id 7a4xvbtt) with correct attribution maintained.

---
*PR created automatically by Jules for task [17593388498095033758](https://jules.google.com/task/17593388498095033758) started by @CloCkWeRX*