### PR TITLE
Add support for Temperature Humidity Sensor SS302 (6lbesej0) via @Sathen

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The integration works locally, but connection to Tuya BLE device requires device
   + Soil moisture sensor (product_id 'ojzlzzsw').
   + SRB-PM01 Soil Moisture Sensor (product_id 'jabotj1z').
   + Temperature Humidity Sensor (product_id 'jm6iasmb', 'tr0kabuq', 'iv7hudlj', 'jm6iasmb')
+  + Temperature Humidity Sensor SS302 (product_id '6lbesej0')
   + Soil Thermo-Hygrometer (product_id 'tv6peegl')
 
 * CO2 sensors (category_id 'co2bj')

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -531,6 +531,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             "tv6peegl": TuyaBLEProductInfo(name="Soil Thermo-Hygrometer"),
             "vlzqwckk": TuyaBLEProductInfo(name="Temperature Humidity Sensor"),
             "tr0kabuq": TuyaBLEProductInfo(name="Temperature Humidity Sensor"),
+            "6lbesej0": TuyaBLEProductInfo(name="Temperature Humidity Sensor SS302"),
         },
     ),
     "znhsb": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -477,6 +477,37 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     ),
                 ),
             ],
+            "6lbesej0": [  # Temperature Humidity Sensor SS302
+                TuyaBLETemperatureMapping(
+                    dp_id=1,
+                    coefficient=10.0,
+                    description=SensorEntityDescription(
+                        key="temp_current",
+                        device_class=SensorDeviceClass.TEMPERATURE,
+                        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=2,
+                    description=SensorEntityDescription(
+                        key="humidity_value",
+                        device_class=SensorDeviceClass.HUMIDITY,
+                        native_unit_of_measurement=PERCENTAGE,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLEBatteryMapping(
+                    dp_id=4,
+                    description=SensorEntityDescription(
+                        key="battery_percentage",
+                        device_class=SensorDeviceClass.BATTERY,
+                        native_unit_of_measurement=PERCENTAGE,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+            ],
             "jm6iasmb": [  # Bluetooth Temperature Humidity Sensor
                 TuyaBLETemperatureMapping(
                     dp_id=1,


### PR DESCRIPTION
This change adds support for the SS302 Temperature Humidity Sensor (product ID: 6lbesej0) in the wsdcg category, including mappings for temperature, humidity, and battery percentage, and lists it in the README. Sathen is attributed in the commit.

---
*PR created automatically by Jules for task [6093952735730967510](https://jules.google.com/task/6093952735730967510) started by @CloCkWeRX*