### PR TITLE
Add support for CS-9 Smart Fingerprint Lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ The integration works locally, but connection to Tuya BLE device requires device
       <td>—</td>
     </tr>
     <tr>
-      <td rowspan="13"><strong>Smart Locks</strong></td>
-      <td rowspan="13"><code>ms</code>, <code>jtmspro</code></td>
+      <td rowspan="14"><strong>Smart Locks</strong></td>
+      <td rowspan="14"><code>ms</code>, <code>jtmspro</code></td>
       <td>Smart Lock</td>
       <td><code>ludzroix</code>, <code>isk2p555</code>, <code>gumrixyt</code>, <code>uamrw6h3</code>, <code>sidhzylo</code>, <code>mqc2hevy</code>, <code>7a4xvbtt</code></td>
       <td>—</td>
@@ -152,6 +152,11 @@ The integration works locally, but connection to Tuya BLE device requires device
       <td>B16</td>
       <td><code>ajk32biq</code></td>
       <td>—</td>
+    </tr>
+    <tr>
+      <td>CS-9 Smart Fingerprint Lock</td>
+      <td><code>pyawczjj</code></td>
+      <td>Experimental.</td>
     </tr>
     <tr>
       <td>Smart Cylinder Lock</td>

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -401,6 +401,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             "z7lj676i": TuyaBLEProductInfo(name="Smart Cylinder Lock", lock=1),
             "hs21i377": TuyaBLEProductInfo(name="Smart Cylinder Lock"),
             "kholoaew": TuyaBLEProductInfo(name="Smart Lock"),
+            "pyawczjj": TuyaBLEProductInfo(name="CS-9 Smart Fingerprint Lock", lock=1),
         },
     ),
     "szjqr": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -299,6 +299,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                     "oyqux5vv",  # LA-01 - Experimental
                     "ajk32biq",  # B16
                     "z7lj676i",  # Smart Cylinder Lock - Experimental
+                    "pyawczjj",  # CS-9 Smart Fingerprint Lock - Experimental
                 ],
                 [
                     TuyaBLESelectMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -315,6 +315,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     "z7lj676i",  # Smart Cylinder Lock - Experimental
                     "hs21i377",  # Smart Cylinder Lock (LVD11_BK)
                     "kholoaew",  # Smart Lock
+                    "pyawczjj",  # CS-9 Smart Fingerprint Lock - Experimental
                 ],
                 [
                     TuyaBLEAlarmLockStateMapping(dp_id=21),


### PR DESCRIPTION
This change registers the Tuya Smart Fingerprint door lock Model CS-9 (Product ID 'pyawczjj') as part of the 'jtmspro' lock category, enabling lock, sensors, and select platforms. The README has been updated to list the CS-9 model with 'Experimental.' status.

---
*PR created automatically by Jules for task [2442369978072476540](https://jules.google.com/task/2442369978072476540) started by @CloCkWeRX*