### PR TITLE
Implement minimal passing test coverage for all basic entities

### DIFF
--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,97 @@
+"""Test for tuya_ble button."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.components.button import ButtonEntityDescription
+from custom_components.tuya_ble.button import TuyaBLEButton, TuyaBLEButtonMapping
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import *
+
+STATE_ON = "activated"
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "button 1",
+                "icon": "",
+                "id": "71",
+                "platform": "button",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_button(hass: HomeAssistant) -> None:
+    # Set up our own custom init for button to avoid mapping issues in __init__.py's init
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Product", lock=1)
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    mapping = TuyaBLEButtonMapping(
+        dp_id=71,
+        description=ButtonEntityDescription(
+            key="bluetooth_unlock",
+            name="Unlock",
+        ),
+        force_add=True,
+    )
+    entity = TuyaBLEButton(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    assert entity.available is False
+
+    coordinator._async_handle_connect()
+    assert entity.available is True
+
+    # Call press
+    entity.press()
+    await hass.async_block_till_done()
+
+    # Verify _send_datapoints was called
+    device._send_datapoints.assert_called_once_with([71])
+
+    # DP 71 was created as DT_BOOL and set to True because product_info has lock=1
+    dp = device.datapoints[71]
+    assert dp is not None
+    assert dp.value is True

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,129 @@
+"""Test for tuya_ble climate."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.components.climate import ClimateEntityDescription, HVACMode, PRESET_AWAY, PRESET_NONE
+from custom_components.tuya_ble.climate import TuyaBLEClimate, TuyaBLEClimateMapping
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Climate 1",
+                "icon": "",
+                "id": "103",
+                "platform": "climate",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_climate(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Climate Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map our climate entity
+    mapping = TuyaBLEClimateMapping(
+        description=ClimateEntityDescription(
+            key="thermostatic_radiator_valve",
+        ),
+        hvac_switch_dp_id=101,
+        hvac_switch_mode=HVACMode.HEAT,
+        hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        preset_mode_dp_ids={PRESET_AWAY: 106, PRESET_NONE: 106},
+        current_temperature_dp_id=102,
+        current_temperature_coefficient=10.0,
+        target_temperature_coefficient=10.0,
+        target_temperature_step=0.5,
+        target_temperature_dp_id=103,
+        target_temperature_min=5.0,
+        target_temperature_max=30.0,
+    )
+
+    entity = TuyaBLEClimate(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial availability and connected check
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+
+    # Test status updates for temperature
+    # Update DP 102 (current_temp) to 220 -> 22.0
+    device.datapoints._update_from_device(102, 0, 0, TuyaBLEDataPointType.DT_VALUE, 220)
+    # Update DP 103 (target_temp) to 42 -> 42 * 0.5 = 21.0
+    device.datapoints._update_from_device(103, 0, 0, TuyaBLEDataPointType.DT_VALUE, 42)
+    # Update DP 101 (hvac switch) to True -> HVACMode.HEAT
+    device.datapoints._update_from_device(101, 0, 0, TuyaBLEDataPointType.DT_BOOL, True)
+    # Update DP 106 (preset) to True -> PRESET_AWAY
+    device.datapoints._update_from_device(106, 0, 0, TuyaBLEDataPointType.DT_BOOL, True)
+
+    entity._handle_coordinator_update()
+
+    assert entity.current_temperature == 22.0
+    assert entity.target_temperature == 21.0
+    assert entity.hvac_mode == HVACMode.HEAT
+    assert entity.preset_mode == PRESET_AWAY
+
+    # Test setting target temperature
+    await entity.async_set_temperature(temperature=23.5)
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([103])
+    # 23.5 * 2 = 47
+    assert device.datapoints[103].value == 47
+
+    # Test setting HVAC mode
+    await entity.async_set_hvac_mode(HVACMode.OFF)
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([101])
+    assert device.datapoints[101].value is False
+
+    # Test setting preset mode
+    await entity.async_set_preset_mode(PRESET_NONE)
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([106])
+    assert device.datapoints[106].value is False

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -1,0 +1,115 @@
+"""Test for tuya_ble cover."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.components.cover import CoverEntityDescription
+from custom_components.tuya_ble.cover import TuyaBLECover, TuyaBLECoverMapping
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Cover 1",
+                "icon": "",
+                "id": "cover",
+                "platform": "cover",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_cover(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Cover Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map our cover entity
+    mapping = TuyaBLECoverMapping(
+        description=CoverEntityDescription(
+            key="ble_blind_controller",
+        ),
+        cover_state_dp_id=1,
+        cover_position_set_dp=2,
+        cover_position_dp_id=3,
+    )
+
+    entity = TuyaBLECover(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+    assert entity.current_cover_position == 0
+
+    # Update coordinator state: position DP 3 to 20 -> current_cover_position = 80
+    device.datapoints._update_from_device(3, 0, 0, TuyaBLEDataPointType.DT_VALUE, 20)
+    entity._handle_coordinator_update()
+    assert entity.current_cover_position == 80
+
+    # Call async_open_cover (sets state DP 1 to 0)
+    await entity.async_open_cover()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([1])
+    assert device.datapoints[1].value == 0
+
+    # Call async_close_cover (sets state DP 1 to 2)
+    await entity.async_close_cover()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([1])
+    assert device.datapoints[1].value == 2
+
+    # Call async_stop_cover (sets state DP 1 to 1)
+    await entity.async_stop_cover()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([1])
+    assert device.datapoints[1].value == 1
+
+    # Call async_set_cover_position (sets position DP 2 to 100 - 70 = 30)
+    await entity.async_set_cover_position(position=70)
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([2])
+    assert device.datapoints[2].value == 30

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,121 @@
+"""Test for tuya_ble light."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from custom_components.tuya_ble.light import TuyaBLELight, TuyaLightEntityDescription
+from custom_components.tuya_ble.tuya_ble.tuya_ble import TuyaBLEDataPointType, TuyaBLEDeviceFunction
+from custom_components.tuya_ble.const import DPCode, DPType
+from custom_components.tuya_ble.tuya_ble.manager import TuyaBLEDeviceCredentials
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Light 1",
+                "icon": "",
+                "id": "switch_led",
+                "platform": "light",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_light(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Light Product")
+
+    # Set up TuyaBLEDeviceCredentials directly
+    device._device_info = TuyaBLEDeviceCredentials(
+        uuid="uuid123",
+        local_key="wV[NcWGUSFF`dSgO",
+        device_id="767823809c9c1f458745",
+        category="dd",
+        product_id="nvfrtxlq",
+        device_name="Light",
+        product_model="Strip Light",
+        product_name="Strip Light",
+        functions=[],
+        status_range=[],
+    )
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    # Populate device.function with DPCode.SWITCH_LED
+    device.function[DPCode.SWITCH_LED] = TuyaBLEDeviceFunction(
+        code=DPCode.SWITCH_LED,
+        dp_id=1,
+        type=DPType.BOOLEAN,
+        values=None,
+    )
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    description = TuyaLightEntityDescription(
+        key=DPCode.SWITCH_LED,
+        name="Led",
+    )
+
+    entity = TuyaBLELight(
+        hass, coordinator, device, product_info, description
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+    assert entity.is_on is False
+
+    # Update coordinator state via updating DP 1
+    device.datapoints._update_from_device(1, 0, 0, TuyaBLEDataPointType.DT_BOOL, True)
+    entity._handle_coordinator_update()
+    assert entity.is_on is True
+
+    # Call turn_off
+    entity.turn_off()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([1])
+    assert device.datapoints[1].value is False
+
+    # Call turn_on
+    entity.turn_on()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([1])
+    assert device.datapoints[1].value is True

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,94 @@
+"""Test for tuya_ble lock."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from custom_components.tuya_ble.lock import TuyaBLELock
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+from custom_components.tuya_ble.const import DPCode
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Lock 1",
+                "icon": "",
+                "id": "lock",
+                "platform": "lock",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_lock(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Lock Product", lock=1)
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    entity = TuyaBLELock(
+        hass, coordinator, device, product_info
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+    # Initial: not motor_state.value -> True (locked) because get_or_create defaults to False
+    assert entity.is_locked is True
+
+    # Update coordinator state to unlocked: "lock_motor_state" = True
+    device.datapoints._update_from_device(DPCode.LOCK_MOTOR_STATE, 0, 0, TuyaBLEDataPointType.DT_BOOL, True)
+    entity._handle_coordinator_update()
+    assert entity.is_locked is False
+
+    # Call async_lock
+    await entity.async_lock()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_called_with([DPCode.MANUAL_LOCK])
+    assert device.datapoints[DPCode.MANUAL_LOCK].value is True
+
+    # Call async_unlock
+    await entity.async_unlock()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_called_with([DPCode.MANUAL_LOCK])
+    assert device.datapoints[DPCode.MANUAL_LOCK].value is False

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,100 @@
+"""Test for tuya_ble number."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.components.number import NumberEntityDescription
+from custom_components.tuya_ble.number import TuyaBLENumber, TuyaBLENumberMapping
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Number 1",
+                "icon": "",
+                "id": "11",
+                "platform": "number",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_number(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Number Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map our number entity
+    mapping = TuyaBLENumberMapping(
+        dp_id=11,
+        description=NumberEntityDescription(
+            key="countdown_duration",
+            native_min_value=1.0,
+            native_max_value=100.0,
+        ),
+        coefficient=10.0,
+        force_add=True,
+    )
+
+    entity = TuyaBLENumber(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+    assert entity.native_value == 1.0
+
+    # Update coordinator state: 150 -> 15.0 (coefficient=10.0)
+    device.datapoints._update_from_device(11, 0, 0, TuyaBLEDataPointType.DT_VALUE, 150)
+    entity._handle_coordinator_update()
+    assert entity.native_value == 15.0
+
+    # Call set_native_value
+    entity.set_native_value(25.0)
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_called_once_with([11])
+    assert device.datapoints[11].value == 250
+    assert entity.native_value == 25.0

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,103 @@
+"""Test for tuya_ble select."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.components.select import SelectEntityDescription
+from custom_components.tuya_ble.select import TuyaBLESelect, TuyaBLESelectMapping
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Select 1",
+                "icon": "",
+                "id": "31",
+                "platform": "select",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_select(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Select Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map our select entity
+    mapping = TuyaBLESelectMapping(
+        dp_id=31,
+        description=SelectEntityDescription(
+            key="beep_volume",
+            options=[
+                "mute",
+                "low",
+                "normal",
+                "high",
+            ],
+        ),
+        force_add=True,
+    )
+
+    entity = TuyaBLESelect(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+    assert entity.current_option is None
+
+    # Update coordinator state: 1 -> "low"
+    device.datapoints._update_from_device(31, 0, 0, TuyaBLEDataPointType.DT_ENUM, 1)
+    entity._handle_coordinator_update()
+    assert entity.current_option == "low"
+
+    # Call select_option
+    entity.select_option("high")
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_called_once_with([31])
+    assert device.datapoints[31].value == 3
+    assert entity.current_option == "high"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,132 @@
+"""Test for tuya_ble sensor."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.components.sensor import SensorEntityDescription
+from custom_components.tuya_ble.sensor import TuyaBLESensor, TuyaBLESensorMapping, rssi_mapping
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Sensor 1",
+                "icon": "",
+                "id": "2",
+                "platform": "sensor",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_sensor(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Sensor Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map our sensor entity
+    mapping = TuyaBLESensorMapping(
+        dp_id=2,
+        description=SensorEntityDescription(
+            key="carbon_dioxide",
+        ),
+        force_add=True,
+    )
+
+    entity = TuyaBLESensor(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+    assert entity.native_value is None
+
+    # Update coordinator state: 600 -> 600
+    device.datapoints._update_from_device(2, 0, 0, TuyaBLEDataPointType.DT_VALUE, 600)
+    entity._handle_coordinator_update()
+    assert entity.native_value == 600
+
+
+async def test_sensor_rssi(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE RSSI",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Sensor Product")
+
+    # Mock rssi via advertisement data
+    device._advertisement_data = Mock()
+    device._advertisement_data.rssi = -65
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    # Map rssi sensor entity
+    entity = TuyaBLESensor(
+        hass, coordinator, device, product_info, rssi_mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Verify rssi value gets pulled
+    coordinator._async_handle_connect()
+    entity._handle_coordinator_update()
+    assert entity.native_value == -65

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,181 @@
+"""Test for tuya_ble switch."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.components.switch import SwitchEntityDescription
+from custom_components.tuya_ble.switch import TuyaBLESwitch, TuyaBLESwitchMapping
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Switch 1",
+                "icon": "",
+                "id": "1",
+                "platform": "switch",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_switch(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Switch Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map our switch entity
+    mapping = TuyaBLESwitchMapping(
+        dp_id=1,
+        description=SwitchEntityDescription(
+            key="water_valve",
+        ),
+        force_add=True,
+    )
+
+    entity = TuyaBLESwitch(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+    assert entity.is_on is False
+
+    # Update coordinator state
+    device.datapoints._update_from_device(1, 0, 0, TuyaBLEDataPointType.DT_BOOL, True)
+    entity._handle_coordinator_update()
+    assert entity.is_on is True
+
+    # Call turn_off
+    entity.turn_off()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([1])
+    assert entity.is_on is False
+
+    # Call turn_on
+    entity.turn_on()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([1])
+    assert entity.is_on is True
+
+
+async def test_switch_bitmap(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE 2",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Switch Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map a switch with bitmap mask (e.g. low battery alarm mapping, mask b"\x02")
+    mapping = TuyaBLESwitchMapping(
+        dp_id=11,
+        description=SwitchEntityDescription(
+            key="low_battery_alarm",
+        ),
+        bitmap_mask=b"\x02",
+        force_add=True,
+    )
+
+    entity = TuyaBLESwitch(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    coordinator._async_handle_connect()
+    assert entity.is_on is False
+
+    # Update coordinator state with bitmap b"\x02" -> should be on
+    device.datapoints._update_from_device(11, 0, 0, TuyaBLEDataPointType.DT_BITMAP, b"\x02")
+    entity._handle_coordinator_update()
+    assert entity.is_on is True
+
+    # Update coordinator state with bitmap b"\x01" -> should be off (doesn't match b"\x02")
+    device.datapoints._update_from_device(11, 0, 0, TuyaBLEDataPointType.DT_BITMAP, b"\x01")
+    entity._handle_coordinator_update()
+    assert entity.is_on is False
+
+    # Call turn_on (should bitwise OR with mask b"\x02")
+    entity.turn_on()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_any_call([11])
+    assert device.datapoints[11].value == b"\x03"  # b"\x01" | b"\x02" = b"\x03"
+
+    # Call turn_off (should bitwise AND with ~mask b"\x02")
+    entity.turn_off()
+    await hass.async_block_till_done()
+    assert device.datapoints[11].value == b"\x01"  # b"\x03" & ~b"\x02" = b"\x01"

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,97 @@
+"""Test for tuya_ble text."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.components.text import TextEntityDescription
+from custom_components.tuya_ble.text import TuyaBLEText, TuyaBLETextMapping
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Text 1",
+                "icon": "",
+                "id": "106",
+                "platform": "text",
+                "restore_on_reconnect": False,
+                "address": "12:23:44"
+            }
+        ],
+    }
+}
+
+
+async def test_text(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Text Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map our text entity
+    mapping = TuyaBLETextMapping(
+        dp_id=106,
+        description=TextEntityDescription(
+            key="battery_pin",
+        ),
+        default_value="0000",
+        force_add=True,
+    )
+
+    entity = TuyaBLEText(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+    assert entity.native_value == "0000"
+
+    # Update coordinator state
+    device.datapoints._update_from_device(106, 0, 0, TuyaBLEDataPointType.DT_STRING, "1234")
+    entity._handle_coordinator_update()
+    assert entity.native_value == "1234"
+
+    # Call set_value
+    entity.set_value("5678")
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_called_once_with([106])
+    assert entity.native_value == "5678"


### PR DESCRIPTION
Added minimal passing test coverage for all basic entity platforms (button, climate, switch, text, number, select, sensor, lock, light, cover) to prevent and detect behavioral regressions.

---
*PR created automatically by Jules for task [8464734846938013848](https://jules.google.com/task/8464734846938013848) started by @CloCkWeRX*