### PR TITLE
Report zwjcy soil sensor humidity DP as soil moisture

### DIFF
--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -950,8 +950,8 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     TuyaBLESensorMapping(
                         dp_id=3,
                         description=SensorEntityDescription(
-                            key="humidity",
-                            device_class=SensorDeviceClass.HUMIDITY,
+                            key="moisture",
+                            device_class=SensorDeviceClass.MOISTURE,
                             native_unit_of_measurement=PERCENTAGE,
                             state_class=SensorStateClass.MEASUREMENT,
                         ),


### PR DESCRIPTION
## Problem

For the `zwjcy` category — **Smartlife Plant Sensor SGS01** (`gvygg3m8`) and **SRB-PM01 Soil Moisture Sensor** (`jabotj1z`) — `dp_id=3` is mapped as:

```python
key="humidity",
device_class=SensorDeviceClass.HUMIDITY,
```

These are **soil** sensors, so `dp_id=3` is soil moisture, not relative air humidity. The current mapping gives the wrong device class (and the wrong icon), and it's inconsistent with the other soil moisture sensors already in `sensor.py`.

## Fix

Change `dp_id=3` for `zwjcy` to:

```python
key="moisture",
device_class=SensorDeviceClass.MOISTURE,
```

This matches the convention already used elsewhere in the same file for soil sensors — `wsdcg`/`ojzlzzsw` and `tv6peegl` both use `key="moisture"` + `SensorDeviceClass.MOISTURE` — and gives the correct moisture device class / water-drop icon.

## ⚠️ Breaking change

This changes the entity_id suffix from `_humidity` to `_moisture` for existing `zwjcy` (`gvygg3m8`, `jabotj1z`) users. Anyone referencing the old `sensor.<id>_humidity` entity in dashboards/automations will need to update it to `sensor.<id>_moisture`. Happy to gate this differently (e.g. keep `key="humidity"` and only switch `device_class`) if you'd prefer to avoid the rename — just let me know.

## Testing

Verified on real hardware:
- SGS01 soil moisture sensor (category `zwjcy`, product `gvygg3m8`, sold as ATLO-SMS1-BLE-TUYA)
- HA 2026.7.x, integration installed via HACS, Central Europe DC
- After the change the entity reports as `sensor.<id>_moisture` with the moisture device class (water-drop icon); temperature/battery unaffected.

Follow-up to #164 (same hardware). This PR is AI-assisted (diagnosed and patched with Claude Code on a live Home Assistant instance, then verified end-to-end).