### PR TITLE
Terminate 'ensure connected' and reconnect tasks on "Bluetooth is already shutdown"

### DIFF
--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -741,12 +741,24 @@ class TuyaBLEDevice:
                         exc_info=True,
                     )
                     continue
-                except BLEAK_EXCEPTIONS:
+                except BLEAK_EXCEPTIONS as ex:
+                    if "Bluetooth is already shutdown" in str(ex):
+                        _LOGGER.debug(
+                            "%s: Bluetooth is already shutdown, terminating connection attempts",
+                            self.address,
+                        )
+                        raise
                     _LOGGER.debug(
                         "%s: communication failed", self.address, exc_info=True
                     )
                     continue
-                except:
+                except Exception as ex:
+                    if "Bluetooth is already shutdown" in str(ex):
+                        _LOGGER.debug(
+                            "%s: Bluetooth is already shutdown, terminating connection attempts",
+                            self.address,
+                        )
+                        raise
                     _LOGGER.debug("%s: unexpected error", self.address, exc_info=True)
                     continue
 
@@ -757,7 +769,13 @@ class TuyaBLEDevice:
                         await self._client.start_notify(
                             CHARACTERISTIC_NOTIFY, self._notification_handler
                         )
-                    except:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
+                    except Exception as ex:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
+                        if "Bluetooth is already shutdown" in str(ex):
+                            _LOGGER.debug(
+                                "%s: Bluetooth is already shutdown, terminating connection attempts",
+                                self.address,
+                            )
+                            raise
                         self._client = None
                         _LOGGER.error(
                             "%s: starting notifications failed",
@@ -783,7 +801,13 @@ class TuyaBLEDevice:
                                 self.address,
                             )
                             continue
-                    except:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
+                    except Exception as ex:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
+                        if "Bluetooth is already shutdown" in str(ex):
+                            _LOGGER.debug(
+                                "%s: Bluetooth is already shutdown, terminating connection attempts",
+                                self.address,
+                            )
+                            raise
                         self._client = None
                         _LOGGER.error(
                             "%s: Sending device info request failed",
@@ -809,7 +833,13 @@ class TuyaBLEDevice:
                                 self.address,
                             )
                             continue
-                    except:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
+                    except Exception as ex:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
+                        if "Bluetooth is already shutdown" in str(ex):
+                            _LOGGER.debug(
+                                "%s: Bluetooth is already shutdown, terminating connection attempts",
+                                self.address,
+                            )
+                            raise
                         self._client = None
                         _LOGGER.error(
                             "%s: Sending pairing request failed",
@@ -846,7 +876,13 @@ class TuyaBLEDevice:
             if self._expected_disconnect:
                 return
             _LOGGER.debug("%s: Reconnect, connection ensured", self.address)
-        except BLEAK_EXCEPTIONS:  # BleakNotFoundError:
+        except BLEAK_EXCEPTIONS as ex:  # BleakNotFoundError:
+            if "Bluetooth is already shutdown" in str(ex):
+                _LOGGER.debug(
+                    "%s: Reconnect failed because Bluetooth is already shutdown; not scheduling another reconnect",
+                    self.address,
+                )
+                return
             _LOGGER.debug(
                 "%s: Reconnect, failed to ensure connection - backing off",
                 self.address,
@@ -1072,6 +1108,12 @@ class TuyaBLEDevice:
         try:
             await self._int_send_packets_locked(packets)
         except BleakDBusError as ex:
+            if "Bluetooth is already shutdown" in str(ex):
+                _LOGGER.debug(
+                    "%s: Bluetooth is already shutdown, not resending packets or reconnecting",
+                    self.address,
+                )
+                raise BleakError("Bluetooth is already shutdown") from ex
             # Disconnect so we can reset state and try again
             await asyncio.sleep(BLEAK_BACKOFF_TIME)
             _LOGGER.debug(
@@ -1087,6 +1129,12 @@ class TuyaBLEDevice:
                 asyncio.create_task(self._reconnect())
             raise BleakError from ex
         except BleakError as ex:
+            if "Bluetooth is already shutdown" in str(ex):
+                _LOGGER.debug(
+                    "%s: Bluetooth is already shutdown, not resending packets or reconnecting",
+                    self.address,
+                )
+                raise
             # Disconnect so we can reset state and try again
             _LOGGER.debug(
                 "%s: RSSI: %s; Disconnecting due to error: %s",
@@ -1111,7 +1159,13 @@ class TuyaBLEDevice:
                         packet,
                         False,
                     )
-                except:
+                except Exception as ex:
+                    if "Bluetooth is already shutdown" in str(ex):
+                        _LOGGER.debug(
+                            "%s: Bluetooth is already shutdown during sending packet",
+                            self.address,
+                        )
+                        raise BleakError("Bluetooth is already shutdown") from ex
                     _LOGGER.error(
                         "%s: Error during sending packet",
                         self.address,

--- a/tests/test_tuya_ble_shutdown.py
+++ b/tests/test_tuya_ble_shutdown.py
@@ -1,0 +1,106 @@
+"""Test for tuya_ble bluetooth shutdown handling."""
+
+import asyncio
+from unittest.mock import Mock, AsyncMock, patch
+import pytest
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDevice
+from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.core import HomeAssistant
+from custom_components.tuya_ble.const import DOMAIN
+
+CONFIG = {
+    "1234": {
+        "address": "11:22:33:44:55:66",
+        "device_id": "767823809c9c1f458745",
+        "protocol_version": "3.3",
+        "local_key": "wV[NcWGUSFF`dSgO",
+        "friendly_name": "Local 3G",
+    }
+}
+
+async def test_ensure_connected_bluetooth_shutdown(hass: HomeAssistant) -> None:
+    """Test that _ensure_connected terminates immediately on bluetooth shutdown error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": "11:22:33:44:55:66",
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33:44:55:66", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+
+    # We patch establish_connection to raise BleakError("Bluetooth is already shutdown")
+    with patch(
+        "custom_components.tuya_ble.tuya_ble.tuya_ble.establish_connection",
+        side_effect=BleakError("Bluetooth is already shutdown"),
+    ) as mock_establish:
+        with pytest.raises(BleakError, match="Bluetooth is already shutdown"):
+            await device._ensure_connected()
+
+        # Assert establish_connection was only called once, not 100 times!
+        assert mock_establish.call_count == 1
+
+
+async def test_reconnect_bluetooth_shutdown(hass: HomeAssistant) -> None:
+    """Test that _reconnect does not schedule another task on bluetooth shutdown."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": "11:22:33:44:55:66",
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33:44:55:66", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+
+    # Mock _ensure_connected to raise BleakError("Bluetooth is already shutdown")
+    with patch.object(
+        device, "_ensure_connected", side_effect=BleakError("Bluetooth is already shutdown")
+    ):
+        with patch("asyncio.create_task") as mock_create_task:
+            await device._reconnect()
+            # Assert create_task was never called to reschedule _reconnect
+            mock_create_task.assert_not_called()
+
+
+async def test_send_packets_locked_bluetooth_shutdown(hass: HomeAssistant) -> None:
+    """Test that _send_packets_locked propagates bluetooth shutdown immediately without retrying/reconnecting."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": "11:22:33:44:55:66",
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33:44:55:66", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+
+    # Set some device client mock
+    client = Mock()
+    client.write_gatt_char = AsyncMock(side_effect=BleakError("Bluetooth is already shutdown"))
+    device._client = client
+
+    with patch("asyncio.create_task") as mock_create_task:
+        with pytest.raises(BleakError, match="Bluetooth is already shutdown"):
+            await device._send_packets_locked([b"\x00"])
+        # Verify no create_task calls were made for reconnection or packet resend
+        mock_create_task.assert_not_called()


### PR DESCRIPTION
Fix https://github.com/ha-tuya-ble/ha_tuya_ble/issues/42

During Home Assistant shutdown, Bleak errors like "Bluetooth is already shutdown" can be raised. When this occurs, instead of retrying connection attempts up to 100 times, rescheduling reconnect tasks via asyncio.create_task, or rescheduling resends of packets, the integration will now immediately abort connection and reconnection loops, preventing delays, CPU usage, and log pollution during shutdown. Comprehensive unit tests have been added in tests/test_tuya_ble_shutdown.py to verify and guard this behavior.

---
*PR created automatically by Jules for task [6643892050349491402](https://jules.google.com/task/6643892050349491402) started by @CloCkWeRX*