### PR TITLE
Add Arlec Smart Button support

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,13 @@ The integration works locally, but connection to Tuya BLE device requires device
       <td><code>0qgrjxum</code></td>
     </tr>
     <tr>
+      <td><strong>Wireless switches</strong></td>
+      <td><code>wxkg</code></td>
+      <td>Arlec Smart Button</td>
+      <td><code>kpzc6pm8</code>, <code>ja5osu5g</code></td>
+      <td>Single/Double click and Long press support via events.</td>
+    </tr>
+    <tr>
       <td rowspan="2"><strong>Battery</strong></td>
       <td rowspan="2"><code>dcb</code></td>
       <td>Parkside Performance Smart Battery 4Ah</td>

--- a/custom_components/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/__init__.py
@@ -31,6 +31,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.TEXT,
     Platform.COVER,
+    Platform.EVENT,
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -293,8 +293,8 @@ class TuyaBLECoordinator(DataUpdateCoordinator[None]):
     @callback
     def _async_handle_update(self, updates: list[TuyaBLEDataPoint]) -> None:
         """Just trigger the callbacks."""
-        self.last_updates = updates
         self._async_handle_connect()
+        self.last_updates = updates
         self.async_set_updated_data(None)
         self.last_updates = None
         info = get_device_product_info(self._device)

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -272,6 +272,7 @@ class TuyaBLECoordinator(DataUpdateCoordinator[None]):
         self._device = device
         self._disconnected: bool = True
         self._unsub_disconnect: CALLBACK_TYPE | None = None
+        self.last_updates: list[TuyaBLEDataPoint] | None = None
         device.register_connected_callback(self._async_handle_connect)
         device.register_callback(self._async_handle_update)
         device.register_disconnected_callback(self._async_handle_disconnect)
@@ -282,6 +283,7 @@ class TuyaBLECoordinator(DataUpdateCoordinator[None]):
 
     @callback
     def _async_handle_connect(self) -> None:
+        self.last_updates = None
         if self._unsub_disconnect is not None:
             self._unsub_disconnect()
         if self._disconnected:
@@ -291,8 +293,10 @@ class TuyaBLECoordinator(DataUpdateCoordinator[None]):
     @callback
     def _async_handle_update(self, updates: list[TuyaBLEDataPoint]) -> None:
         """Just trigger the callbacks."""
+        self.last_updates = updates
         self._async_handle_connect()
         self.async_set_updated_data(None)
+        self.last_updates = None
         info = get_device_product_info(self._device)
         if info and info.fingerbot and info.fingerbot.manual_control != 0:
             for update in updates:
@@ -308,6 +312,7 @@ class TuyaBLECoordinator(DataUpdateCoordinator[None]):
     @callback
     def _set_disconnected(self, _: None) -> None:
         """Invoke the idle timeout callback, called when the alarm fires."""
+        self.last_updates = None
         self._disconnected = True
         self._unsub_disconnect = None
         self.async_update_listeners()
@@ -348,6 +353,18 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                 name="CO2 Detector",
             ),
         },
+    ),
+    "wxkg": TuyaBLECategoryInfo(
+        products={
+            "kpzc6pm8": TuyaBLEProductInfo(
+                name="Arlec Smart Button",
+                manufacturer="Arlec",
+            ),
+            "ja5osu5g": TuyaBLEProductInfo(
+                name="Arlec Smart Button",
+                manufacturer="Arlec",
+            ),
+        }
     ),
     "ms": TuyaBLECategoryInfo(
         products={

--- a/custom_components/tuya_ble/event.py
+++ b/custom_components/tuya_ble/event.py
@@ -1,0 +1,153 @@
+"""The Tuya BLE integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+
+from homeassistant.components.event import (
+    EventDeviceClass,
+    EventEntity,
+    EventEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+from .devices import TuyaBLEData, TuyaBLEEntity, TuyaBLEProductInfo
+from .tuya_ble import TuyaBLEDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class TuyaBLEEventMapping:
+    """Model a DP, description and default values"""
+
+    dp_id: int
+    description: EventEntityDescription
+    force_add: bool = True
+    event_types: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TuyaBLECategoryEventMapping:
+    """Models a dict of products and their mappings"""
+
+    products: dict[str, list[TuyaBLEEventMapping]] | None = None
+    mapping: list[TuyaBLEEventMapping] | None = None
+
+
+mapping: dict[str, TuyaBLECategoryEventMapping] = {
+    "wxkg": TuyaBLECategoryEventMapping(
+        products={
+            **dict.fromkeys(
+                ["kpzc6pm8", "ja5osu5g"],
+                [
+                    TuyaBLEEventMapping(
+                        dp_id=1,
+                        description=EventEntityDescription(
+                            key="event",
+                            device_class=EventDeviceClass.BUTTON,
+                        ),
+                        event_types=["single_click", "double_click", "long_press"],
+                    )
+                ],
+            )
+        }
+    )
+}
+
+
+def get_mapping_by_device(device: TuyaBLEDevice) -> list[TuyaBLEEventMapping]:
+    category = mapping.get(device.category)
+    if category is not None and category.products is not None:
+        product_mapping = category.products.get(device.product_id)
+        if product_mapping is not None:
+            return product_mapping
+        if category.mapping is not None:
+            return category.mapping
+
+    return []
+
+
+class TuyaBLEEvent(TuyaBLEEntity, EventEntity):
+    """Representation of a Tuya BLE event entity."""
+
+    platform = Platform.EVENT
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: DataUpdateCoordinator,
+        device: TuyaBLEDevice,
+        product: TuyaBLEProductInfo,
+        mapping: TuyaBLEEventMapping,
+    ) -> None:
+        super().__init__(hass, coordinator, device, product, mapping.description)
+        self._mapping = mapping
+        self._attr_event_types = mapping.event_types
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if not getattr(self._coordinator, "last_updates", None):
+            return
+
+        # Check if our DP was in the updates list
+        dp = next(
+            (
+                update
+                for update in self._coordinator.last_updates
+                if update.id == self._mapping.dp_id
+            ),
+            None,
+        )
+        if dp is None:
+            return
+
+        # Let's see what is the value of the DP
+        val = dp.value
+
+        if isinstance(val, int):
+            if 0 <= val < len(self._attr_event_types):
+                event_type = self._attr_event_types[val]
+            else:
+                event_type = None
+        elif isinstance(val, str):
+            if val in self._attr_event_types:
+                event_type = val
+            else:
+                event_type = None
+        else:
+            event_type = None
+
+        if event_type is not None:
+            self._trigger_event(event_type)
+            self.async_write_ha_state()
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Tuya BLE event entities."""
+    data: TuyaBLEData = hass.data[DOMAIN][entry.entry_id]
+    mappings = get_mapping_by_device(data.device)
+    entities: list[TuyaBLEEvent] = []
+    for mapping in mappings:
+        if mapping.force_add or data.device.datapoints.has_id(mapping.dp_id):
+            entities.append(
+                TuyaBLEEvent(
+                    hass,
+                    data.coordinator,
+                    data.device,
+                    data.product,
+                    mapping,
+                )
+            )
+    async_add_entities(entities)

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -188,6 +188,16 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
             ]
         }
     ),
+    "wxkg": TuyaBLECategorySensorMapping(
+        products={
+            **dict.fromkeys(
+                ["kpzc6pm8", "ja5osu5g"],
+                [
+                    TuyaBLEBatteryMapping(dp_id=10),
+                ],
+            ),
+        }
+    ),
     "ms": TuyaBLECategorySensorMapping(
         products={
             **dict.fromkeys(

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -63,6 +63,11 @@
                 "name": "Unlock"
             }
         },
+        "event": {
+            "event": {
+                "name": "Event"
+            }
+        },
         "number": {
             "brightness": {
                 "name": "Brightness"

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -63,6 +63,11 @@
                 "name": "Unlock"
             }
         },
+        "event": {
+            "event": {
+                "name": "Event"
+            }
+        },
         "number": {
             "brightness": {
                 "name": "Brightness"

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,137 @@
+"""Test for tuya_ble event."""
+
+from unittest.mock import Mock, AsyncMock
+from homeassistant.core import HomeAssistant
+from homeassistant.components.event import EventEntityDescription, EventDeviceClass
+from custom_components.tuya_ble.event import TuyaBLEEvent, TuyaBLEEventMapping
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import *
+
+CONFIG = {
+    DEVICE_NAME: {
+        **DEVICE_CONFIG,
+        "entities": [
+            {
+                "entity_category": "None",
+                "friendly_name": "Button Event",
+                "icon": "",
+                "id": "1",
+                "platform": "event",
+                "restore_on_reconnect": False,
+                "address": "12:23:44",
+            }
+        ],
+    }
+}
+
+
+async def test_event(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import (
+        TuyaBLEDevice,
+        TuyaBLEProductInfo,
+        TuyaBLECoordinator,
+        TuyaBLEData,
+    )
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE Event",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Event Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map our event entity
+    mapping = TuyaBLEEventMapping(
+        dp_id=1,
+        description=EventEntityDescription(
+            key="event",
+            device_class=EventDeviceClass.BUTTON,
+        ),
+        event_types=["single_click", "double_click", "long_press"],
+        force_add=True,
+    )
+
+    entity = TuyaBLEEvent(hass, coordinator, device, product_info, mapping)
+    entity.async_write_ha_state = Mock()
+    entity._trigger_event = Mock()
+    coordinator.async_add_listener(entity._handle_coordinator_update)
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+
+    # 1. Update unrelated DP (DP 10) to coordinator
+    device.datapoints._update_from_device(10, 0, 0, TuyaBLEDataPointType.DT_VALUE, 80)
+    dp10 = device.datapoints[10]
+
+    # Send update packet containing only DP 10
+    coordinator._async_handle_update([dp10])
+
+    # Verify that event trigger was NOT called
+    entity._trigger_event.assert_not_called()
+
+    # 2. Update DP 1 (value "single_click" as string) to coordinator
+    device.datapoints._update_from_device(
+        1, 0, 0, TuyaBLEDataPointType.DT_STRING, "single_click"
+    )
+    dp1 = device.datapoints[1]
+
+    # Send update packet containing DP 1
+    coordinator._async_handle_update([dp1])
+
+    # Verify event trigger was called with "single_click"
+    entity._trigger_event.assert_called_once_with("single_click")
+    entity._trigger_event.reset_mock()
+
+    # 3. Verify clearing of last_updates: If another DP (10) updates, DP 1 is not in updates, event should NOT re-trigger
+    coordinator._async_handle_update([dp10])
+    entity._trigger_event.assert_not_called()
+
+    # 4. Update DP 1 (value 2 as integer/enum index -> "long_press") to coordinator
+    device.datapoints._update_from_device(1, 0, 0, TuyaBLEDataPointType.DT_ENUM, 2)
+    dp1_enum = device.datapoints[1]
+
+    coordinator._async_handle_update([dp1_enum])
+    entity._trigger_event.assert_called_once_with("long_press")
+    entity._trigger_event.reset_mock()
+
+    # 5. Connect/Disconnect should clear last_updates and should NOT trigger stale events
+    coordinator.last_updates = [dp1_enum]  # Inject stale update manually
+    coordinator._async_handle_connect()
+    assert coordinator.last_updates is None
+    entity._trigger_event.assert_not_called()
+
+    coordinator.last_updates = [dp1_enum]  # Inject stale update manually
+    coordinator._set_disconnected(None)
+    assert coordinator.last_updates is None
+    entity._trigger_event.assert_not_called()


### PR DESCRIPTION
Support Arlec Smart Button (ZG101Z / SG022HA) in Tuya BLE as an event entity for clicks/presses, and a sensor for battery percentage. Adds the Home Assistant `event` platform to handle stateless clicks correctly without duplicate triggers during connection changes.

---
*PR created automatically by Jules for task [5945416362281792173](https://jules.google.com/task/5945416362281792173) started by @CloCkWeRX*