### PR TITLE
Update translations to sync with en.json

### DIFF
--- a/custom_components/tuya_ble/translations/de.json
+++ b/custom_components/tuya_ble/translations/de.json
@@ -63,6 +63,11 @@
                 "name": "Entriegeln"
             }
         },
+        "event": {
+            "event": {
+                "name": "Ereignis"
+            }
+        },
         "number": {
             "brightness": {
                 "name": "Helligkeit"
@@ -261,6 +266,15 @@
             },
             "unlock_password": {
                 "name": "Zuletzt verwendetes Passwort"
+            },
+            "unlock_key": {
+                "name": "Zuletzt verwendeter Schlüssel"
+            },
+            "unlock_dynamic": {
+                "name": "Zuletzt verwendetes dynamisches Passwort"
+            },
+            "unlock_ble": {
+                "name": "Zuletzt verwendetes Bluetooth"
             }
         },
         "switch": {

--- a/custom_components/tuya_ble/translations/es.json
+++ b/custom_components/tuya_ble/translations/es.json
@@ -63,6 +63,11 @@
                 "name": "Desbloquear"
             }
         },
+        "event": {
+            "event": {
+                "name": "Evento"
+            }
+        },
         "number": {
             "brightness": {
                 "name": "Brillo"
@@ -261,6 +266,15 @@
             },
             "unlock_password": {
                 "name": "Última contraseña utilizada"
+            },
+            "unlock_key": {
+                "name": "Última llave utilizada"
+            },
+            "unlock_dynamic": {
+                "name": "Última contraseña dinámica utilizada"
+            },
+            "unlock_ble": {
+                "name": "Último Bluetooth utilizado"
             }
         },
         "switch": {

--- a/custom_components/tuya_ble/translations/fr.json
+++ b/custom_components/tuya_ble/translations/fr.json
@@ -63,6 +63,11 @@
                 "name": "Déverrouiller"
             }
         },
+        "event": {
+            "event": {
+                "name": "Événement"
+            }
+        },
         "number": {
             "brightness": {
                 "name": "Luminosité"
@@ -261,6 +266,15 @@
             },
             "unlock_password": {
                 "name": "Dernier mot de passe utilisé"
+            },
+            "unlock_key": {
+                "name": "Dernière clé utilisée"
+            },
+            "unlock_dynamic": {
+                "name": "Dernier mot de passe dynamique utilisé"
+            },
+            "unlock_ble": {
+                "name": "Dernier Bluetooth utilisé"
             }
         },
         "switch": {

--- a/custom_components/tuya_ble/translations/it.json
+++ b/custom_components/tuya_ble/translations/it.json
@@ -63,6 +63,11 @@
                 "name": "Sblocca"
             }
         },
+        "event": {
+            "event": {
+                "name": "Evento"
+            }
+        },
         "number": {
             "brightness": {
                 "name": "Luminosità"
@@ -261,6 +266,15 @@
             },
             "unlock_password": {
                 "name": "Ultima password utilizzata"
+            },
+            "unlock_key": {
+                "name": "Ultima chiave utilizzata"
+            },
+            "unlock_dynamic": {
+                "name": "Ultima password dinamica utilizzata"
+            },
+            "unlock_ble": {
+                "name": "Ultimo Bluetooth utilizzato"
             }
         },
         "switch": {

--- a/custom_components/tuya_ble/translations/pt-BR.json
+++ b/custom_components/tuya_ble/translations/pt-BR.json
@@ -63,6 +63,11 @@
                 "name": "Desbloquear"
             }
         },
+        "event": {
+            "event": {
+                "name": "Evento"
+            }
+        },
         "number": {
             "brightness": {
                 "name": "Brilho"
@@ -261,6 +266,15 @@
             },
             "unlock_password": {
                 "name": "Última senha utilizada"
+            },
+            "unlock_key": {
+                "name": "Última chave utilizada"
+            },
+            "unlock_dynamic": {
+                "name": "Última senha dinâmica utilizada"
+            },
+            "unlock_ble": {
+                "name": "Último Bluetooth utilizado"
             }
         },
         "switch": {

--- a/custom_components/tuya_ble/translations/zh-Hans.json
+++ b/custom_components/tuya_ble/translations/zh-Hans.json
@@ -63,6 +63,11 @@
                 "name": "解锁"
             }
         },
+        "event": {
+            "event": {
+                "name": "事件"
+            }
+        },
         "number": {
             "brightness": {
                 "name": "亮度"
@@ -261,6 +266,15 @@
             },
             "unlock_password": {
                 "name": "上次使用的密码"
+            },
+            "unlock_key": {
+                "name": "上次使用的钥匙"
+            },
+            "unlock_dynamic": {
+                "name": "上次使用的动态密码"
+            },
+            "unlock_ble": {
+                "name": "上次使用的蓝牙"
             }
         },
         "switch": {


### PR DESCRIPTION
Updates the translation files for French (fr.json), Italian (it.json), German (de.json), Spanish (es.json), Portuguese (Brazil) (pt-BR.json), and Simplified Chinese (zh-Hans.json) to synchronize them with the English reference file (en.json). Added translations for 'Event', 'Last used Key', 'Last used Dynamic Password', and 'Last used Bluetooth' to each of these translation files.

---
*PR created automatically by Jules for task [11017854051812022278](https://jules.google.com/task/11017854051812022278) started by @CloCkWeRX*