### PR TITLE
fix: Add support for TH05 Temperature Sensor (vyfoip9h, 1jvidcsf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ The integration works locally, but connection to Tuya BLE device requires device
       <td>—</td>
     </tr>
     <tr>
-      <td rowspan="5"><strong>Temperature and humidity sensors</strong></td>
-      <td rowspan="5"><code>wsdcg</code>, <code>zwjcy</code></td>
+      <td rowspan="6"><strong>Temperature and humidity sensors</strong></td>
+      <td rowspan="6"><code>wsdcg</code>, <code>zwjcy</code></td>
       <td>Soil moisture sensor</td>
       <td><code>ojzlzzsw</code></td>
       <td>—</td>
@@ -102,6 +102,11 @@ The integration works locally, but connection to Tuya BLE device requires device
     <tr>
       <td>Temperature Humidity Sensor SS302</td>
       <td><code>6lbesej0</code></td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td>TH05 Temperature Sensor</td>
+      <td><code>vyfoip9h</code>, <code>1jvidcsf</code></td>
       <td>—</td>
     </tr>
     <tr>

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -570,6 +570,8 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             "vlzqwckk": TuyaBLEProductInfo(name="Temperature Humidity Sensor"),
             "tr0kabuq": TuyaBLEProductInfo(name="Temperature Humidity Sensor"),
             "6lbesej0": TuyaBLEProductInfo(name="Temperature Humidity Sensor SS302"),
+            "vyfoip9h": TuyaBLEProductInfo(name="Temperature Humidity Sensor"),
+            "1jvidcsf": TuyaBLEProductInfo(name="Temperature Humidity Sensor"),
         },
     ),
     "znhsb": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -556,6 +556,36 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     ),
                 ),
             ],
+            **dict.fromkeys(
+                ["vyfoip9h", "1jvidcsf"],
+                [
+                    TuyaBLENumberMapping(
+                        dp_id=23,
+                        description=NumberEntityDescription(
+                            key="temperature_calibration",
+                            icon="mdi:thermometer-lines",
+                            native_max_value=2.0,
+                            native_min_value=-2.0,
+                            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+                            native_step=0.1,
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                        coefficient=10.0,
+                    ),
+                    TuyaBLENumberMapping(
+                        dp_id=24,
+                        description=NumberEntityDescription(
+                            key="humidity_calibration",
+                            icon="mdi:water-check",
+                            native_max_value=10,
+                            native_min_value=-10,
+                            native_unit_of_measurement=PERCENTAGE,
+                            native_step=1,
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                ],
+            ),
         },
     ),
     "znhsb": TuyaBLECategoryNumberMapping(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -561,7 +561,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
     "wsdcg": TuyaBLECategorySelectMapping(
         products={
             **dict.fromkeys(
-                ["ojzlzzsw", "iv7hudlj", "jm6iasmb", "vlzqwckk", "tr0kabuq"],
+                ["ojzlzzsw", "iv7hudlj", "jm6iasmb", "vlzqwckk", "tr0kabuq", "vyfoip9h", "1jvidcsf"],
                 [TuyaBLETemperatureUnitMapping(dp_id=9)],
             )
         },

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -561,7 +561,15 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
     "wsdcg": TuyaBLECategorySelectMapping(
         products={
             **dict.fromkeys(
-                ["ojzlzzsw", "iv7hudlj", "jm6iasmb", "vlzqwckk", "tr0kabuq", "vyfoip9h", "1jvidcsf"],
+                [
+                    "ojzlzzsw",
+                    "iv7hudlj",
+                    "jm6iasmb",
+                    "vlzqwckk",
+                    "tr0kabuq",
+                    "vyfoip9h",
+                    "1jvidcsf",
+                ],
                 [TuyaBLETemperatureUnitMapping(dp_id=9)],
             )
         },

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -690,7 +690,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                             state_class=SensorStateClass.MEASUREMENT,
                         ),
                     ),
-                ]
+                ],
             ),
             "jm6iasmb": [  # Bluetooth Temperature Humidity Sensor
                 TuyaBLETemperatureMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -658,37 +658,40 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     ),
                 ),
             ],
-            "6lbesej0": [  # Temperature Humidity Sensor SS302
-                TuyaBLETemperatureMapping(
-                    dp_id=1,
-                    coefficient=10.0,
-                    description=SensorEntityDescription(
-                        key="temp_current",
-                        device_class=SensorDeviceClass.TEMPERATURE,
-                        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-                        state_class=SensorStateClass.MEASUREMENT,
+            **dict.fromkeys(
+                ["6lbesej0", "vyfoip9h", "1jvidcsf"],
+                [
+                    TuyaBLETemperatureMapping(
+                        dp_id=1,
+                        coefficient=10.0,
+                        description=SensorEntityDescription(
+                            key="temp_current",
+                            device_class=SensorDeviceClass.TEMPERATURE,
+                            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+                            state_class=SensorStateClass.MEASUREMENT,
+                        ),
                     ),
-                ),
-                TuyaBLESensorMapping(
-                    dp_id=2,
-                    description=SensorEntityDescription(
-                        key="humidity_value",
-                        device_class=SensorDeviceClass.HUMIDITY,
-                        native_unit_of_measurement=PERCENTAGE,
-                        state_class=SensorStateClass.MEASUREMENT,
+                    TuyaBLESensorMapping(
+                        dp_id=2,
+                        description=SensorEntityDescription(
+                            key="humidity_value",
+                            device_class=SensorDeviceClass.HUMIDITY,
+                            native_unit_of_measurement=PERCENTAGE,
+                            state_class=SensorStateClass.MEASUREMENT,
+                        ),
                     ),
-                ),
-                TuyaBLEBatteryMapping(
-                    dp_id=4,
-                    description=SensorEntityDescription(
-                        key="battery_percentage",
-                        device_class=SensorDeviceClass.BATTERY,
-                        native_unit_of_measurement=PERCENTAGE,
-                        entity_category=EntityCategory.DIAGNOSTIC,
-                        state_class=SensorStateClass.MEASUREMENT,
+                    TuyaBLEBatteryMapping(
+                        dp_id=4,
+                        description=SensorEntityDescription(
+                            key="battery_percentage",
+                            device_class=SensorDeviceClass.BATTERY,
+                            native_unit_of_measurement=PERCENTAGE,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            state_class=SensorStateClass.MEASUREMENT,
+                        ),
                     ),
-                ),
-            ],
+                ]
+            ),
             "jm6iasmb": [  # Bluetooth Temperature Humidity Sensor
                 TuyaBLETemperatureMapping(
                     dp_id=1,

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -69,11 +69,17 @@
             }
         },
         "number": {
+            "ble_unlock_check": {
+                "name": "Unlock"
+            },
             "brightness": {
                 "name": "Brightness"
             },
             "carbon_dioxide_alarm_level": {
                 "name": "Alarm level"
+            },
+            "countdown": {
+                "name": "Irrigation duration"
             },
             "countdown_duration": {
                 "name": "Irrigation duration"
@@ -84,14 +90,14 @@
             "countdown_duration_z2": {
                 "name": "Irrigation duration - Zone 2"
             },
-            "countdown": {
-                "name": "Irrigation duration"
-            },
             "down_position": {
                 "name": "Down position"
             },
             "hold_time": {
                 "name": "Hold time"
+            },
+            "humidity_calibration": {
+                "name": "Humidity calibration"
             },
             "program_idle_position": {
                 "name": "Idle position"
@@ -105,11 +111,11 @@
             "reporting_period": {
                 "name": "Reporting period"
             },
+            "temperature_calibration": {
+                "name": "Temperature calibration"
+            },
             "up_position": {
                 "name": "Up position"
-            },
-            "ble_unlock_check": {
-                "name": "Unlock"
             }
         },
         "select": {
@@ -354,4 +360,3 @@
         }
     }
 }
-

--- a/custom_components/tuya_ble/translations/de.json
+++ b/custom_components/tuya_ble/translations/de.json
@@ -69,11 +69,17 @@
             }
         },
         "number": {
+            "ble_unlock_check": {
+                "name": "Entriegeln"
+            },
             "brightness": {
                 "name": "Helligkeit"
             },
             "carbon_dioxide_alarm_level": {
                 "name": "Alarmstufe"
+            },
+            "countdown": {
+                "name": "Bewässerungsdauer"
             },
             "countdown_duration": {
                 "name": "Bewässerungsdauer"
@@ -84,14 +90,14 @@
             "countdown_duration_z2": {
                 "name": "Bewässerungsdauer - Zone 2"
             },
-            "countdown": {
-                "name": "Bewässerungsdauer"
-            },
             "down_position": {
                 "name": "Untere Position"
             },
             "hold_time": {
                 "name": "Haltezeit"
+            },
+            "humidity_calibration": {
+                "name": "Luftfeuchtigkeitskalibrierung"
             },
             "program_idle_position": {
                 "name": "Ruheposition"
@@ -105,11 +111,11 @@
             "reporting_period": {
                 "name": "Berichtszeitraum"
             },
+            "temperature_calibration": {
+                "name": "Temperaturkalibrierung"
+            },
             "up_position": {
                 "name": "Obere Position"
-            },
-            "ble_unlock_check": {
-                "name": "Entriegeln"
             }
         },
         "select": {

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -69,11 +69,17 @@
             }
         },
         "number": {
+            "ble_unlock_check": {
+                "name": "Unlock"
+            },
             "brightness": {
                 "name": "Brightness"
             },
             "carbon_dioxide_alarm_level": {
                 "name": "Alarm level"
+            },
+            "countdown": {
+                "name": "Irrigation duration"
             },
             "countdown_duration": {
                 "name": "Irrigation duration"
@@ -84,14 +90,14 @@
             "countdown_duration_z2": {
                 "name": "Irrigation duration - Zone 2"
             },
-            "countdown": {
-                "name": "Irrigation duration"
-            },
             "down_position": {
                 "name": "Down position"
             },
             "hold_time": {
                 "name": "Hold time"
+            },
+            "humidity_calibration": {
+                "name": "Humidity calibration"
             },
             "program_idle_position": {
                 "name": "Idle position"
@@ -105,11 +111,11 @@
             "reporting_period": {
                 "name": "Reporting period"
             },
+            "temperature_calibration": {
+                "name": "Temperature calibration"
+            },
             "up_position": {
                 "name": "Up position"
-            },
-            "ble_unlock_check": {
-                "name": "Unlock"
             }
         },
         "select": {
@@ -362,4 +368,3 @@
         }
     }
 }
-

--- a/custom_components/tuya_ble/translations/es.json
+++ b/custom_components/tuya_ble/translations/es.json
@@ -69,11 +69,17 @@
             }
         },
         "number": {
+            "ble_unlock_check": {
+                "name": "Desbloquear"
+            },
             "brightness": {
                 "name": "Brillo"
             },
             "carbon_dioxide_alarm_level": {
                 "name": "Nivel de alarma"
+            },
+            "countdown": {
+                "name": "Duración del riego"
             },
             "countdown_duration": {
                 "name": "Duración del riego"
@@ -84,14 +90,14 @@
             "countdown_duration_z2": {
                 "name": "Duración del riego - Zona 2"
             },
-            "countdown": {
-                "name": "Duración del riego"
-            },
             "down_position": {
                 "name": "Posición abajo"
             },
             "hold_time": {
                 "name": "Tiempo de espera"
+            },
+            "humidity_calibration": {
+                "name": "Calibración de humedad"
             },
             "program_idle_position": {
                 "name": "Posición de reposo"
@@ -105,11 +111,11 @@
             "reporting_period": {
                 "name": "Período de reporte"
             },
+            "temperature_calibration": {
+                "name": "Calibración de temperatura"
+            },
             "up_position": {
                 "name": "Posición arriba"
-            },
-            "ble_unlock_check": {
-                "name": "Desbloquear"
             }
         },
         "select": {

--- a/custom_components/tuya_ble/translations/fr.json
+++ b/custom_components/tuya_ble/translations/fr.json
@@ -69,11 +69,17 @@
             }
         },
         "number": {
+            "ble_unlock_check": {
+                "name": "Déverrouiller"
+            },
             "brightness": {
                 "name": "Luminosité"
             },
             "carbon_dioxide_alarm_level": {
                 "name": "Niveau d'alarme"
+            },
+            "countdown": {
+                "name": "Durée d'arrosage"
             },
             "countdown_duration": {
                 "name": "Durée d'arrosage"
@@ -84,14 +90,14 @@
             "countdown_duration_z2": {
                 "name": "Durée d'arrosage - Zone 2"
             },
-            "countdown": {
-                "name": "Durée d'arrosage"
-            },
             "down_position": {
                 "name": "Position basse"
             },
             "hold_time": {
                 "name": "Temps de maintien"
+            },
+            "humidity_calibration": {
+                "name": "Calibrage de l'humidité"
             },
             "program_idle_position": {
                 "name": "Position de repos"
@@ -105,11 +111,11 @@
             "reporting_period": {
                 "name": "Période de rapport"
             },
+            "temperature_calibration": {
+                "name": "Calibrage de la température"
+            },
             "up_position": {
                 "name": "Position haute"
-            },
-            "ble_unlock_check": {
-                "name": "Déverrouiller"
             }
         },
         "select": {

--- a/custom_components/tuya_ble/translations/it.json
+++ b/custom_components/tuya_ble/translations/it.json
@@ -69,11 +69,17 @@
             }
         },
         "number": {
+            "ble_unlock_check": {
+                "name": "Sblocca"
+            },
             "brightness": {
                 "name": "Luminosità"
             },
             "carbon_dioxide_alarm_level": {
                 "name": "Livello d'allarme"
+            },
+            "countdown": {
+                "name": "Durata irrigazione"
             },
             "countdown_duration": {
                 "name": "Durata irrigazione"
@@ -84,14 +90,14 @@
             "countdown_duration_z2": {
                 "name": "Durata irrigazione - Zona 2"
             },
-            "countdown": {
-                "name": "Durata irrigazione"
-            },
             "down_position": {
                 "name": "Posizione giù"
             },
             "hold_time": {
                 "name": "Tempo di mantenimento"
+            },
+            "humidity_calibration": {
+                "name": "Calibrazione dell'umidità"
             },
             "program_idle_position": {
                 "name": "Posizione di riposo"
@@ -105,11 +111,11 @@
             "reporting_period": {
                 "name": "Periodo di segnalazione"
             },
+            "temperature_calibration": {
+                "name": "Calibrazione della temperatura"
+            },
             "up_position": {
                 "name": "Posizione su"
-            },
-            "ble_unlock_check": {
-                "name": "Sblocca"
             }
         },
         "select": {

--- a/custom_components/tuya_ble/translations/pt-BR.json
+++ b/custom_components/tuya_ble/translations/pt-BR.json
@@ -69,11 +69,17 @@
             }
         },
         "number": {
+            "ble_unlock_check": {
+                "name": "Desbloquear"
+            },
             "brightness": {
                 "name": "Brilho"
             },
             "carbon_dioxide_alarm_level": {
                 "name": "Nível do alarme"
+            },
+            "countdown": {
+                "name": "Duração da irrigação"
             },
             "countdown_duration": {
                 "name": "Duração da irrigação"
@@ -84,14 +90,14 @@
             "countdown_duration_z2": {
                 "name": "Duração da irrigação - Zona 2"
             },
-            "countdown": {
-                "name": "Duração da irrigação"
-            },
             "down_position": {
                 "name": "Posição para baixo"
             },
             "hold_time": {
                 "name": "Tempo de retenção"
+            },
+            "humidity_calibration": {
+                "name": "Calibração de umidade"
             },
             "program_idle_position": {
                 "name": "Posição de repouso"
@@ -105,11 +111,11 @@
             "reporting_period": {
                 "name": "Período de relatório"
             },
+            "temperature_calibration": {
+                "name": "Calibração de temperatura"
+            },
             "up_position": {
                 "name": "Posição para cima"
-            },
-            "ble_unlock_check": {
-                "name": "Desbloquear"
             }
         },
         "select": {

--- a/custom_components/tuya_ble/translations/zh-Hans.json
+++ b/custom_components/tuya_ble/translations/zh-Hans.json
@@ -69,11 +69,17 @@
             }
         },
         "number": {
+            "ble_unlock_check": {
+                "name": "解锁"
+            },
             "brightness": {
                 "name": "亮度"
             },
             "carbon_dioxide_alarm_level": {
                 "name": "报警级别"
+            },
+            "countdown": {
+                "name": "灌溉时长"
             },
             "countdown_duration": {
                 "name": "灌溉时长"
@@ -84,14 +90,14 @@
             "countdown_duration_z2": {
                 "name": "灌溉时长 - 区域 2"
             },
-            "countdown": {
-                "name": "灌溉时长"
-            },
             "down_position": {
                 "name": "下限位置"
             },
             "hold_time": {
                 "name": "保持时间"
+            },
+            "humidity_calibration": {
+                "name": "湿度校准"
             },
             "program_idle_position": {
                 "name": "空闲位置"
@@ -105,11 +111,11 @@
             "reporting_period": {
                 "name": "上报周期"
             },
+            "temperature_calibration": {
+                "name": "温度校准"
+            },
             "up_position": {
                 "name": "上限位置"
-            },
-            "ble_unlock_check": {
-                "name": "解锁"
             }
         },
         "select": {


### PR DESCRIPTION
Fix #216 

This change registers and maps the TH05 temperature/humidity sensors (models vyfoip9h and 1jvidcsf) under the 'wsdcg' category. It maps the temperature, humidity, battery sensors, temperature unit selection, and calibration (temperature and humidity) number entities, and adds comprehensive translation keys for the new number entities across all supported languages, as well as updating the supported devices table in README.md.

---
*PR created automatically by Jules for task [10357801000347039601](https://jules.google.com/task/10357801000347039601) started by @CloCkWeRX*