### PR TITLE
chore: Add GitHub Action to validate PR conventional commits

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,21 @@
+name: "Validate PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  validate:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title against Conventional Commits spec
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Created a new GitHub Actions workflow `.github/workflows/validate-pr.yml` to validate that PR titles adhere to the Conventional Commits specification. This workflow uses the `amannn/action-semantic-pull-request@v6` action on the `pull_request_target` event as requested.

---
*PR created automatically by Jules for task [8105585051217215715](https://jules.google.com/task/8105585051217215715) started by @CloCkWeRX*