### PR TITLE
feat: Add dynamic GATT characteristic selection for multiple Tuya BLE generations

### DIFF
--- a/custom_components/tuya_ble/config_flow.py
+++ b/custom_components/tuya_ble/config_flow.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowHandler, FlowResult
 
-from .tuya_ble import SERVICE_UUID, TuyaBLEDeviceCredentials
+from .tuya_ble import SERVICE_UUIDS, TuyaBLEDeviceCredentials
 
 from .const import (
     TUYA_COUNTRIES,
@@ -317,7 +317,7 @@ class TuyaBLEConfigFlow(ConfigFlow, domain=DOMAIN):
                     discovery.address in current_addresses
                     or discovery.address in self._discovered_devices
                     or discovery.service_data is None
-                    or not SERVICE_UUID in discovery.service_data.keys()
+                    or not any(uuid in discovery.service_data for uuid in SERVICE_UUIDS)
                 ):
                     continue
                 self._discovered_devices[discovery.address] = discovery

--- a/custom_components/tuya_ble/manifest.json
+++ b/custom_components/tuya_ble/manifest.json
@@ -5,6 +5,10 @@
     {
       "connectable": true,
       "service_data_uuid": "0000a201-0000-1000-8000-00805f9b34fb"
+    },
+    {
+      "connectable": true,
+      "service_data_uuid": "0000fd50-0000-1000-8000-00805f9b34fb"
     }
   ],
   "codeowners": [

--- a/custom_components/tuya_ble/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/tuya_ble/__init__.py
@@ -5,6 +5,7 @@ __version__ = "0.2.3"
 
 from .const import (
     SERVICE_UUID,
+    SERVICE_UUIDS,
     TuyaBLEDataPointType,
 )
 from .manager import (
@@ -21,4 +22,5 @@ __all__ = [
     "TuyaBLEDevice",
     "TuyaBLEDeviceCredentials",
     "SERVICE_UUID",
+    "SERVICE_UUIDS",
 ]

--- a/custom_components/tuya_ble/tuya_ble/const.py
+++ b/custom_components/tuya_ble/tuya_ble/const.py
@@ -6,11 +6,28 @@ GATT_MTU = 20
 
 DEFAULT_ATTEMPTS = 0xFFFF
 
+# GATT characteristics and services. Added support for multiple generations/services.
+# Dynamic selection mechanism contributed by @Shirkamdev (https://github.com/Shirkamdev/ha_tuya_ble).
+
 CHARACTERISTIC_NOTIFY = "00002b10-0000-1000-8000-00805f9b34fb"
 CHARACTERISTIC_WRITE = "00002b11-0000-1000-8000-00805f9b34fb"
 
-# SERVICE_UUID = "0000a201-0000-1000-8000-00805f9b34fb"
+CHARACTERISTIC_NOTIFY_FD50 = "00000002-0000-1001-8001-00805f9b07d0"
+CHARACTERISTIC_WRITE_FD50 = "00000001-0000-1001-8001-00805f9b07d0"
+
 SERVICE_UUID = "0000fd50-0000-1000-8000-00805f9b34fb"
+SERVICE_UUID_A201 = "0000a201-0000-1000-8000-00805f9b34fb"
+
+# Tuple of all supported Service UUIDs
+SERVICE_UUIDS = (SERVICE_UUID_A201, SERVICE_UUID)
+
+# Maps each Tuya BLE GATT service UUID to its (notify, write) characteristic UUIDs.
+# Different protocol/firmware generations expose the same data over different
+# characteristic UUIDs, so the actual pair must be picked per connected device.
+SERVICE_CHARACTERISTICS = {
+    SERVICE_UUID_A201: (CHARACTERISTIC_NOTIFY, CHARACTERISTIC_WRITE),
+    SERVICE_UUID: (CHARACTERISTIC_NOTIFY_FD50, CHARACTERISTIC_WRITE_FD50),
+}
 
 SERVICE_UUID_TEMP = "0000a201-0000-1000-8000-00805f9b34fb"
 

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -32,7 +32,9 @@ from .const import (
     GATT_MTU,
     MANUFACTURER_DATA_ID,
     RESPONSE_WAIT_TIMEOUT,
+    SERVICE_CHARACTERISTICS,
     SERVICE_UUID_TEMP,
+    SERVICE_UUIDS,
     TuyaBLECode,
     TuyaBLEDataPointType,
 )
@@ -286,6 +288,8 @@ class TuyaBLEDevice:
         self._operation_lock = asyncio.Lock()
         self._connect_lock = asyncio.Lock()
         self._client: BleakClientWithServiceCache | None = None
+        self._characteristic_notify = CHARACTERISTIC_NOTIFY
+        self._characteristic_write = CHARACTERISTIC_WRITE
         self._expected_disconnect = False
         self._connected_callbacks: list[Callable[[], None]] = []
         self._callbacks: list[Callable[[list[TuyaBLEDataPoint]], None]] = []
@@ -414,9 +418,13 @@ class TuyaBLEDevice:
         raw_uuid: bytes | None = None
         if self._advertisement_data:
             if self._advertisement_data.service_data:
-                service_data = self._advertisement_data.service_data.get(
-                    SERVICE_UUID_TEMP
-                )
+                service_data = None
+                for service_uuid in SERVICE_UUIDS:
+                    service_data = self._advertisement_data.service_data.get(
+                        service_uuid
+                    )
+                    if service_data:
+                        break
                 if service_data and len(service_data) > 1:
                     match service_data[0]:
                         case 0:
@@ -685,7 +693,7 @@ class TuyaBLEDevice:
             self._expected_disconnect = True
             self._client = None
             if client and client.is_connected:
-                await client.stop_notify(CHARACTERISTIC_NOTIFY)
+                await client.stop_notify(self._characteristic_notify)
                 await client.disconnect()
         self._clean_input()
         async with self._seq_num_lock:
@@ -765,9 +773,17 @@ class TuyaBLEDevice:
                 if client and client.is_connected:
                     _LOGGER.debug("%s: Connected; RSSI: %s", self.address, self.rssi)
                     self._client = client
+                    self._characteristic_notify = CHARACTERISTIC_NOTIFY
+                    self._characteristic_write = CHARACTERISTIC_WRITE
+                    # Support for additional GATT characteristics from @Shirkamdev
+                    for notify_uuid, write_uuid in SERVICE_CHARACTERISTICS.values():
+                        if client.services.get_characteristic(notify_uuid):
+                            self._characteristic_notify = notify_uuid
+                            self._characteristic_write = write_uuid
+                            break
                     try:
                         await self._client.start_notify(
-                            CHARACTERISTIC_NOTIFY, self._notification_handler
+                            self._characteristic_notify, self._notification_handler
                         )
                     except Exception as ex:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
                         if "Bluetooth is already shutdown" in str(ex):
@@ -1155,7 +1171,7 @@ class TuyaBLEDevice:
                 try:
                     # _LOGGER.debug("%s: Sending packet: %s", self.address, packet.hex())
                     await self._client.write_gatt_char(
-                        CHARACTERISTIC_WRITE,
+                        self._characteristic_write,
                         packet,
                         False,
                     )

--- a/tests/test_gatt_characteristics.py
+++ b/tests/test_gatt_characteristics.py
@@ -1,0 +1,163 @@
+"""Test for dynamic GATT characteristic selection."""
+
+from unittest.mock import Mock, AsyncMock, patch
+import pytest
+from bleak.backends.device import BLEDevice
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDevice
+from custom_components.tuya_ble.tuya_ble.manager import TuyaBLEDeviceCredentials
+from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.core import HomeAssistant
+from custom_components.tuya_ble.const import DOMAIN
+
+CONFIG = {
+    "1234": {
+        "address": "11:22:33:44:55:66",
+        "device_id": "767823809c9c1f458745",
+        "protocol_version": "3.3",
+        "local_key": "wV[NcWGUSFF`dSgO",
+        "friendly_name": "Local 3G",
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_gatt_characteristic_selection_classic(hass: HomeAssistant) -> None:
+    """Test that classic GATT characteristics are selected when present."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": "11:22:33:44:55:66",
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(
+        name="bob", address="11:22:33:44:55:66", details="", rssi=-50
+    )
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+
+    credentials = TuyaBLEDeviceCredentials(
+        uuid="12345678901234567890",
+        local_key="wV[NcWGUSFF`dSgO",
+        device_id="767823809c9c1f458745",
+        category="ms",
+        product_id="kpn4zaf7",
+        device_name="Mock Lock",
+        product_model="BSTUOKEY",
+        product_name="BSTUOKEY",
+        functions=[],
+        status_range=[],
+    )
+
+    with patch.object(manager, "get_device_credentials", return_value=credentials):
+        device = TuyaBLEDevice(manager, ble_device)
+        await device.initialize()
+        device._is_paired = True
+
+        # Mock Client
+        client = Mock()
+        client.is_connected = True
+        client.start_notify = AsyncMock()
+
+        # Get characteristic mock setup: classic notify exists, fd50 notify does not
+        def get_char(uuid):
+            if uuid == "00002b10-0000-1000-8000-00805f9b34fb":
+                return Mock()
+            return None
+
+        client.services.get_characteristic = Mock(side_effect=get_char)
+
+        with patch(
+            "custom_components.tuya_ble.tuya_ble.tuya_ble.establish_connection",
+            return_value=client,
+        ):
+            with patch.object(
+                device, "_send_packet_while_connected", return_value=True
+            ):
+                await device._ensure_connected()
+
+                assert (
+                    device._characteristic_notify
+                    == "00002b10-0000-1000-8000-00805f9b34fb"
+                )
+                assert (
+                    device._characteristic_write
+                    == "00002b11-0000-1000-8000-00805f9b34fb"
+                )
+                client.start_notify.assert_called_with(
+                    "00002b10-0000-1000-8000-00805f9b34fb", device._notification_handler
+                )
+
+
+@pytest.mark.asyncio
+async def test_gatt_characteristic_selection_fd50(hass: HomeAssistant) -> None:
+    """Test that FD50 GATT characteristics are selected when present."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": "11:22:33:44:55:66",
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(
+        name="bob", address="11:22:33:44:55:66", details="", rssi=-50
+    )
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+
+    credentials = TuyaBLEDeviceCredentials(
+        uuid="12345678901234567890",
+        local_key="wV[NcWGUSFF`dSgO",
+        device_id="767823809c9c1f458745",
+        category="ms",
+        product_id="kpn4zaf7",
+        device_name="Mock Lock",
+        product_model="BSTUOKEY",
+        product_name="BSTUOKEY",
+        functions=[],
+        status_range=[],
+    )
+
+    with patch.object(manager, "get_device_credentials", return_value=credentials):
+        device = TuyaBLEDevice(manager, ble_device)
+        await device.initialize()
+        device._is_paired = True
+
+        # Mock Client
+        client = Mock()
+        client.is_connected = True
+        client.start_notify = AsyncMock()
+
+        # Get characteristic mock setup: fd50 notify exists, classic notify does not
+        def get_char(uuid):
+            if uuid == "00000002-0000-1001-8001-00805f9b07d0":
+                return Mock()
+            return None
+
+        client.services.get_characteristic = Mock(side_effect=get_char)
+
+        with patch(
+            "custom_components.tuya_ble.tuya_ble.tuya_ble.establish_connection",
+            return_value=client,
+        ):
+            with patch.object(
+                device, "_send_packet_while_connected", return_value=True
+            ):
+                await device._ensure_connected()
+
+                assert (
+                    device._characteristic_notify
+                    == "00000002-0000-1001-8001-00805f9b07d0"
+                )
+                assert (
+                    device._characteristic_write
+                    == "00000001-0000-1001-8001-00805f9b07d0"
+                )
+                client.start_notify.assert_called_with(
+                    "00000002-0000-1001-8001-00805f9b07d0", device._notification_handler
+                )


### PR DESCRIPTION
Integrated dynamic discovery and selection of classic and FD50 GATT characteristics for Tuya BLE devices. This supports multiple service generations/UUIDs cleanly and dynamically at runtime. Contribution is attributed to @Shirkamdev.

---
*PR created automatically by Jules for task [702717597158090008](https://jules.google.com/task/702717597158090008) started by @CloCkWeRX*