### PR TITLE
fix: Add support for HCT-626 Dual Water Timer (closes #208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,10 +292,15 @@ The integration works locally, but connection to Tuya BLE device requires device
       <td>Experimental.</td>
     </tr>
     <tr>
-      <td rowspan="7"><strong>Water valve controller</strong></td>
-      <td rowspan="7"><code>sfkzq</code></td>
+      <td rowspan="8"><strong>Water valve controller</strong></td>
+      <td rowspan="8"><code>sfkzq</code></td>
       <td>Water valve controller</td>
       <td><code>nxquc5lb</code></td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td>HCT-626 Dual Water Timer</td>
+      <td><code>smd9kj1n</code></td>
       <td>—</td>
     </tr>
     <tr>

--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -220,6 +220,16 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
                     ),
                 ),
             ],
+            "smd9kj1n": [  # HCT-626 Dual Water Timer
+                TuyaBLEBinarySensorMapping(
+                    dp_id=53,
+                    description=BinarySensorEntityDescription(
+                        key="low_battery",
+                        device_class=BinarySensorDeviceClass.BATTERY,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+            ],
         },
     ),
     "jtmspro": TuyaBLECategoryBinarySensorMapping(

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -650,6 +650,9 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             "tqzkwarw": TuyaBLEProductInfo(
                 name="HCT-611 Water Timer",
             ),
+            "smd9kj1n": TuyaBLEProductInfo(
+                name="HCT-626 Dual Water Timer",
+            ),
         },
     ),
     "ggq": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -731,6 +731,32 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     ),
                 ),
             ],
+            "smd9kj1n": [  # HCT-626 Dual Water Timer
+                TuyaBLENumberMapping(
+                    dp_id=17,
+                    description=NumberEntityDescription(
+                        key="countdown_duration_z1",
+                        icon="mdi:timer",
+                        native_max_value=60,
+                        native_min_value=1,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
+                        native_step=1,
+                    ),
+                    coefficient=60.0,
+                ),
+                TuyaBLENumberMapping(
+                    dp_id=18,
+                    description=NumberEntityDescription(
+                        key="countdown_duration_z2",
+                        icon="mdi:timer",
+                        native_max_value=60,
+                        native_min_value=1,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
+                        native_step=1,
+                    ),
+                    coefficient=60.0,
+                ),
+            ],
             **dict.fromkeys(
                 ["46zia2nz", "1fcnd8xk", "0axr5s0b", "d4vpmigg"],
                 [

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-
 import logging
+from typing import Callable
 
 from homeassistant.components.select import (
     SelectEntityDescription,
@@ -29,6 +29,10 @@ from .tuya_ble import TuyaBLEDataPointType, TuyaBLEDevice
 _LOGGER = logging.getLogger(__name__)
 
 
+TuyaBLESelectGetter = Callable[["TuyaBLESelect", TuyaBLEProductInfo], str | None] | None
+TuyaBLESelectSetter = Callable[["TuyaBLESelect", TuyaBLEProductInfo, str], None] | None
+
+
 @dataclass
 class TuyaBLESelectMapping:
     """Model a DP, description and default values"""
@@ -37,6 +41,8 @@ class TuyaBLESelectMapping:
     description: SelectEntityDescription
     force_add: bool = True
     dp_type: TuyaBLEDataPointType | None = None
+    getter: TuyaBLESelectGetter = None
+    setter: TuyaBLESelectSetter = None
 
 
 @dataclass
@@ -119,6 +125,43 @@ class TuyaBLETemperatureUnitMapping(TuyaBLESelectMapping):
     )
 
 
+# Bidirectional mapping for Weather Delay on HCT-626
+WEATHER_DELAY_MAP = {
+    "cancel": "cancel",
+    "1": "24h",
+    "2": "48h",
+    "3": "72h",
+    "4": "96h",
+    "5": "120h",
+    "6": "144h",
+    "7": "168h",
+}
+WEATHER_DELAY_REV_MAP = {v: k for k, v in WEATHER_DELAY_MAP.items()}
+
+
+def get_hct626_weather_delay(
+    self: TuyaBLESelect, product: TuyaBLEProductInfo
+) -> str | None:
+    datapoint = self._device.datapoints[self._mapping.dp_id]
+    if datapoint and datapoint.value is not None:
+        val = str(datapoint.value)
+        return WEATHER_DELAY_MAP.get(val, val)
+    return None
+
+
+def set_hct626_weather_delay(
+    self: TuyaBLESelect, product: TuyaBLEProductInfo, value: str
+) -> None:
+    dp_val = WEATHER_DELAY_REV_MAP.get(value, value)
+    datapoint = self._device.datapoints.get_or_create(
+        self._mapping.dp_id,
+        TuyaBLEDataPointType.DT_STRING,
+        dp_val,
+    )
+    if datapoint:
+        self._hass.create_task(datapoint.set_value(dp_val))
+
+
 mapping: dict[str, TuyaBLECategorySelectMapping] = {
     "sfkzq": TuyaBLECategorySelectMapping(
         products={
@@ -161,6 +204,14 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                         ],
                         entity_category=EntityCategory.CONFIG,
                     ),
+                ),
+            ],
+            "smd9kj1n": [  # HCT-626 Dual Water Timer
+                TuyaBLEWeatherDelayMapping(
+                    dp_id=45,
+                    dp_type=TuyaBLEDataPointType.DT_STRING,
+                    getter=get_hct626_weather_delay,
+                    setter=set_hct626_weather_delay,
                 ),
             ],
             **dict.fromkeys(
@@ -687,12 +738,15 @@ class TuyaBLESelect(TuyaBLEEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
+        if self._mapping.getter:
+            return self._mapping.getter(self, self._product)
+
         # Raw value
         value: str | None = None
         datapoint = self._device.datapoints[self._mapping.dp_id]
         if datapoint:
             value = datapoint.value
-            if 0 <= value < len(self._attr_options):
+            if isinstance(value, int) and 0 <= value < len(self._attr_options):
                 return self._attr_options[value]
 
             return value
@@ -700,6 +754,10 @@ class TuyaBLESelect(TuyaBLEEntity, SelectEntity):
 
     def select_option(self, value: str) -> None:
         """Change the selected option."""
+        if self._mapping.setter:
+            self._mapping.setter(self, self._product, value)
+            return
+
         if value in self._attr_options:
             int_value = self._attr_options.index(value)
             datapoint = self._device.datapoints.get_or_create(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1390,6 +1390,93 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                 ),
                 TuyaBLEWorkStateMapping(dp_id=12),
             ],
+            "smd9kj1n": [  # HCT-626 Dual Water Timer
+                TuyaBLEBatteryMapping(
+                    dp_id=47,
+                    coefficient=20.0,
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=42,
+                    description=SensorEntityDescription(
+                        key="weather_delay_remaining",
+                        icon="mdi:weather-cloudy-clock",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.HOURS,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=44,
+                    dp_type=TuyaBLEDataPointType.DT_STRING,
+                    description=SensorEntityDescription(
+                        key="weather",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=["sunny", "cloudy", "rainy", "snowy", "null"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=101,
+                    description=SensorEntityDescription(
+                        key="use_time_z1",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=102,
+                    description=SensorEntityDescription(
+                        key="use_time_z2",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=103,
+                    description=SensorEntityDescription(
+                        key="spray_time_z1",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=104,
+                    description=SensorEntityDescription(
+                        key="spray_time_z2",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=105,
+                    dp_type=TuyaBLEDataPointType.DT_STRING,
+                    description=SensorEntityDescription(
+                        key="work_state_z1",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=["idle", "manual", "spray", "timing"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=106,
+                    dp_type=TuyaBLEDataPointType.DT_STRING,
+                    description=SensorEntityDescription(
+                        key="work_state_z2",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=["idle", "manual", "spray", "timing"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+            ],
             "0axr5s0b": [  # Valve Controller
                 TuyaBLEBatteryMapping(dp_id=7),
                 TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -1,402 +1,439 @@
 {
-    "config": {
-        "abort": {
-            "no_unconfigured_devices": "No unconfigured devices found."
-        },
-        "error": {
-            "device_not_registered": "Device is not registered in Tuya cloud",
-            "invalid_auth": "Invalid authentication",
-            "login_error": "Login error ({code}): {msg}"
-        },
-        "flow_title": "{name}",
-        "step": {
-            "device": {
-                "data": {
-                    "address": "Tuya BLE device"
-                },
-                "description": "Select Tuya BLE device to setup. Device must be registered in the cloud using the mobile application. It's better to unbind the device from Tuya Bluetooth gateway, if any."
-            },
-            "login": {
-                "data": {
-                    "access_id": "Tuya IoT Access ID",
-                    "access_secret": "Tuya IoT Access Secret",
-                    "country_code": "Country",
-                    "password": "Password",
-                    "username": "Account"
-                },
-                "description": "Tuya BLE requires obtaining encryption key from Tuya cloud. Almost all devices only need to access the cloud once during setup.\n\nRefer to documentation of Tuya integration to retrieve the cloud credentials {url}\n\nEnter your Tuya credentials."
-            }
-        }
+  "config": {
+    "abort": {
+      "no_unconfigured_devices": "No unconfigured devices found."
     },
-    "entity": {
-        "binary_sensor": {
-            "fault": {
-                "name": "Fault"
-            },
-            "lack_water": {
-                "name": "Lack of water"
-            },
-            "low_battery": {
-                "name": "Battery"
-            },
-            "lock_motor_state": {
-                "name": "Motor State"
-            },
-            "low_temp": {
-                "name": "Low temperature"
-            },
-            "motor_fault": {
-                "name": "Motor fault"
-            },
-            "sensor_fault": {
-                "name": "Sensor fault"
-            }
-        },
-        "button": {
-            "push": {
-                "name": "Push"
-            },
-            "ble_unlock_check": {
-                "name": "Unlock"
-            },
-            "bluetooth_unlock": {
-                "name": "Unlock"
-            }
-        },
-        "event": {
-            "event": {
-                "name": "Event"
-            }
-        },
-        "number": {
-            "ble_unlock_check": {
-                "name": "Unlock"
-            },
-            "brightness": {
-                "name": "Brightness"
-            },
-            "carbon_dioxide_alarm_level": {
-                "name": "Alarm level"
-            },
-            "countdown": {
-                "name": "Irrigation duration"
-            },
-            "countdown_duration": {
-                "name": "Irrigation duration"
-            },
-            "countdown_duration_z1": {
-                "name": "Irrigation duration - Zone 1"
-            },
-            "countdown_duration_z2": {
-                "name": "Irrigation duration - Zone 2"
-            },
-            "down_position": {
-                "name": "Down position"
-            },
-            "hold_time": {
-                "name": "Hold time"
-            },
-            "humidity_calibration": {
-                "name": "Humidity calibration"
-            },
-            "program_idle_position": {
-                "name": "Idle position"
-            },
-            "program_repeats_count": {
-                "name": "Repeats count"
-            },
-            "recommended_water_intake": {
-                "name": "Recommended water intake"
-            },
-            "reporting_period": {
-                "name": "Reporting period"
-            },
-            "temperature_calibration": {
-                "name": "Temperature calibration"
-            },
-            "up_position": {
-                "name": "Up position"
-            }
-        },
-        "select": {
-            "beep_volume": {
-                "name": "Lock Volume"
-            },
-            "language": {
-                "name": "Lock Language"
-            },
-            "fingerbot_mode": {
-                "name": "Mode",
-                "state": {
-                    "program": "Program",
-                    "push": "Push",
-                    "switch": "Switch"
-                }
-            },
-            "weather_delay": {
-                "name": "Weather delay"
-            },
-            "smart_weather": {
-                "name": "Smart weather"
-            },
-            "reminder_mode": {
-                "name": "Reminder mode",
-                "state": {
-                    "interval_reminder": "Interval",
-                    "schedule_reminder": "Schedule"
-                }
-            },
-            "temperature_unit": {
-                "name": "Temperature unit"
-            },
-            "mode": {
-                "name": "Cleaning mode",
-                "state": {
-                    "smart": "Smart",
-                    "z_mode": "Z-Mode",
-                    "n_mode": "N-Mode",
-                    "edge": "Edge",
-                    "spot": "Spot"
-                }
-            },
-            "direction_control": {
-                "name": "Direction",
-                "state": {
-                    "forward": "Forward",
-                    "backward": "Backward",
-                    "turn_left": "Turn left",
-                    "turn_right": "Turn right",
-                    "stop": "Stop"
-                }
-            }
-        },
-        "sensor": {
-            "alarm_lock": {
-                "name": "Alarm",
-                "state": {
-                    "wrong_finger": "Wrong Fingerprint",
-                    "wrong_password": "Wrong Password",
-                    "low_battery": "Low Battery",
-                    "power_off": "Power off"
-                }
-            },
-            "power_off": {
-                "name": "Power off"
-            },
-            "battery": {
-                "name": "Battery"
-            },
-            "battery_charging": {
-                "name": "Battery charging",
-                "state": {
-                    "charged": "Charged",
-                    "charging": "Charging",
-                    "not_charging": "Not charging"
-                }
-            },
-            "battery_state": {
-                "name": "Battery state",
-                "state": {
-                    "high": "High",
-                    "low": "Low",
-                    "middle": "Medium",
-                    "normal": "Normal"
-                }
-            },
-            "carbon_dioxide": {
-                "name": "Carbon dioxide"
-            },
-            "carbon_dioxide_alarm": {
-                "name": "Carbon dioxide level",
-                "state": {
-                    "alarm": "Alarm",
-                    "normal": "Normal"
-                }
-            },
-            "day_usage_after_reset": {
-                "name": "Daily usage after reset"
-            },
-            "day_water_usage": {
-                "name": "Daily water usage"
-            },
-            "flow_velocity": {
-                "name": "Flow rate"
-            },
-            "humidity": {
-                "name": "Humidity"
-            },
-            "low_battery": {
-                "name": "Low Battery"
-            },
-            "moisture": {
-                "name": "Moisture"
-            },
-            "work_state": {
-                "name": "Work state"
-            },
-            "residual_electricity": {
-                "name": "Battery"
-            },
-            "signal_strength": {
-                "name": "Signal strength"
-            },
-            "temperature": {
-                "name": "Temperature"
-            },
-            "time_left": {
-                "name": "Remaining irrigation time"
-            },
-            "total_usage_after_reset": {
-                "name": "Total usage after reset"
-            },
-            "use_time_z1": {
-                "name": "Last irrigation time - Zone 1"
-            },
-            "use_time_z2": {
-                "name": "Last irrigation time - Zone 2"
-            },
-            "use_time": {
-                "name": "Accumulated use time"
-            },
-            "use_time_one": {
-                "name": "Last irrigation time"
-            },
-            "water_intake": {
-                "name": "Water intake"
-            },
-            "water_once": {
-                "name": "Last session water usage"
-            },
-            "water_use_data": {
-                "name": "Total water usage"
-            },
-            "wrong_finger": {
-                "name": "Wrong Fingerprint"
-            },
-            "wrong_password": {
-                "name": "Wrong Password"
-            },
-            "unlock_fingerprint": {
-                "name": "Last used Fingerprint"
-            },
-            "unlock_card": {
-                "name": "Last used Card"
-            },
-            "unlock_password": {
-                "name": "Last used Password"
-            },
-            "unlock_key": {
-                "name": "Last used Key"
-            },
-            "unlock_dynamic": {
-                "name": "Last used Dynamic Password"
-            },
-            "unlock_ble": {
-                "name": "Last used Bluetooth"
-            },
-            "unlock_phone_remote": {
-                "name": "Last used remote phone"
-            }
-        },
-        "switch": {
-            "automatic_lock": {
-                "name": "Automatic lock"
-            },
-            "antifreeze": {
-                "name": "Antifreeze"
-            },
-            "carbon_dioxide_alarm_switch": {
-                "name": "Alarm enabled"
-            },
-            "carbon_dioxide_severely_exceed_alarm": {
-                "name": "Severely exceed alarm"
-            },
-            "child_lock": {
-                "name": "Child Lock"
-            },
-            "lock_motor_state": {
-                "name": "Motor State"
-            },
-            "low_battery_alarm": {
-                "name": "Low battery alarm"
-            },
-            "manual_control": {
-                "name": "Manual control"
-            },
-            "program": {
-                "name": "Program"
-            },
-            "program_repeat_forever": {
-                "name": "Repeat forever"
-            },
-            "programming_mode": {
-                "name": "Programming Mode"
-            },
-            "programming_switch": {
-                "name": "Programming Switch"
-            },
-            "reverse_positions": {
-                "name": "Reverse positions"
-            },
-            "switch": {
-                "name": "Switch"
-            },
-            "water_scale_proof": {
-                "name": "Anti-scale"
-            },
-            "water_valve": {
-                "name": "Irrigation valve"
-            },
-            "water_valve_z1": {
-                "name": "Irrigation valve - Zone 1"
-            },
-            "water_valve_z2": {
-                "name": "Irrigation valve - Zone 2"
-            },
-            "weather_switch": {
-                "name": "Weather switch"
-            },
-            "window_check": {
-                "name": "Window Check"
-            },
-            "window_cleaner_switch": {
-                "name": "Cleaning"
-            },
-            "water_auto": {
-                "name": "Auto water spray"
-            }
-        },
-        "text": {
-            "program": {
-                "name": "Program: position[/time];..."
-            }
-        },
-        "vacuum": {
-            "vacuum": {
-                "name": "Window Cleaner"
-            },
-            "clean_time": {
-                "name": "Clean time"
-            }
-        }
+    "error": {
+      "device_not_registered": "Device is not registered in Tuya cloud",
+      "invalid_auth": "Invalid authentication",
+      "login_error": "Login error ({code}): {msg}"
     },
-    "options": {
-        "error": {
-            "device_not_registered": "Device is not registered in Tuya cloud",
-            "invalid_auth": "Invalid authentication",
-            "login_error": "Login error ({code}): {msg}"
+    "flow_title": "{name}",
+    "step": {
+      "device": {
+        "data": {
+          "address": "Tuya BLE device"
         },
-        "step": {
-            "login": {
-                "data": {
-                    "access_id": "Tuya IoT Access ID",
-                    "access_secret": "Tuya IoT Access Secret",
-                    "country_code": "Country",
-                    "password": "Password",
-                    "username": "Account"
-                },
-                "description": "Refer to documentation of Tuya integration to retrieve the cloud credentials {url}\n\nEnter your Tuya credentials."
-            }
-        }
+        "description": "Select Tuya BLE device to setup. Device must be registered in the cloud using the mobile application. It's better to unbind the device from Tuya Bluetooth gateway, if any."
+      },
+      "login": {
+        "data": {
+          "access_id": "Tuya IoT Access ID",
+          "access_secret": "Tuya IoT Access Secret",
+          "country_code": "Country",
+          "password": "Password",
+          "username": "Account"
+        },
+        "description": "Tuya BLE requires obtaining encryption key from Tuya cloud. Almost all devices only need to access the cloud once during setup.\n\nRefer to documentation of Tuya integration to retrieve the cloud credentials {url}\n\nEnter your Tuya credentials."
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "fault": {
+        "name": "Fault"
+      },
+      "lack_water": {
+        "name": "Lack of water"
+      },
+      "low_battery": {
+        "name": "Battery"
+      },
+      "lock_motor_state": {
+        "name": "Motor State"
+      },
+      "low_temp": {
+        "name": "Low temperature"
+      },
+      "motor_fault": {
+        "name": "Motor fault"
+      },
+      "sensor_fault": {
+        "name": "Sensor fault"
+      }
+    },
+    "button": {
+      "push": {
+        "name": "Push"
+      },
+      "ble_unlock_check": {
+        "name": "Unlock"
+      },
+      "bluetooth_unlock": {
+        "name": "Unlock"
+      }
+    },
+    "event": {
+      "event": {
+        "name": "Event"
+      }
+    },
+    "number": {
+      "ble_unlock_check": {
+        "name": "Unlock"
+      },
+      "brightness": {
+        "name": "Brightness"
+      },
+      "carbon_dioxide_alarm_level": {
+        "name": "Alarm level"
+      },
+      "countdown": {
+        "name": "Irrigation duration"
+      },
+      "countdown_duration": {
+        "name": "Irrigation duration"
+      },
+      "countdown_duration_z1": {
+        "name": "Irrigation duration - Zone 1"
+      },
+      "countdown_duration_z2": {
+        "name": "Irrigation duration - Zone 2"
+      },
+      "down_position": {
+        "name": "Down position"
+      },
+      "hold_time": {
+        "name": "Hold time"
+      },
+      "humidity_calibration": {
+        "name": "Humidity calibration"
+      },
+      "program_idle_position": {
+        "name": "Idle position"
+      },
+      "program_repeats_count": {
+        "name": "Repeats count"
+      },
+      "recommended_water_intake": {
+        "name": "Recommended water intake"
+      },
+      "reporting_period": {
+        "name": "Reporting period"
+      },
+      "temperature_calibration": {
+        "name": "Temperature calibration"
+      },
+      "up_position": {
+        "name": "Up position"
+      }
+    },
+    "select": {
+      "beep_volume": {
+        "name": "Lock Volume"
+      },
+      "language": {
+        "name": "Lock Language"
+      },
+      "fingerbot_mode": {
+        "name": "Mode",
+        "state": {
+          "program": "Program",
+          "push": "Push",
+          "switch": "Switch"
+        }
+      },
+      "weather_delay": {
+        "name": "Weather delay"
+      },
+      "smart_weather": {
+        "name": "Smart weather"
+      },
+      "reminder_mode": {
+        "name": "Reminder mode",
+        "state": {
+          "interval_reminder": "Interval",
+          "schedule_reminder": "Schedule"
+        }
+      },
+      "temperature_unit": {
+        "name": "Temperature unit"
+      },
+      "mode": {
+        "name": "Cleaning mode",
+        "state": {
+          "smart": "Smart",
+          "z_mode": "Z-Mode",
+          "n_mode": "N-Mode",
+          "edge": "Edge",
+          "spot": "Spot"
+        }
+      },
+      "direction_control": {
+        "name": "Direction",
+        "state": {
+          "forward": "Forward",
+          "backward": "Backward",
+          "turn_left": "Turn left",
+          "turn_right": "Turn right",
+          "stop": "Stop"
+        }
+      }
+    },
+    "sensor": {
+      "alarm_lock": {
+        "name": "Alarm",
+        "state": {
+          "wrong_finger": "Wrong Fingerprint",
+          "wrong_password": "Wrong Password",
+          "low_battery": "Low Battery",
+          "power_off": "Power off"
+        }
+      },
+      "power_off": {
+        "name": "Power off"
+      },
+      "battery": {
+        "name": "Battery"
+      },
+      "battery_charging": {
+        "name": "Battery charging",
+        "state": {
+          "charged": "Charged",
+          "charging": "Charging",
+          "not_charging": "Not charging"
+        }
+      },
+      "battery_state": {
+        "name": "Battery state",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "middle": "Medium",
+          "normal": "Normal"
+        }
+      },
+      "carbon_dioxide": {
+        "name": "Carbon dioxide"
+      },
+      "carbon_dioxide_alarm": {
+        "name": "Carbon dioxide level",
+        "state": {
+          "alarm": "Alarm",
+          "normal": "Normal"
+        }
+      },
+      "day_usage_after_reset": {
+        "name": "Daily usage after reset"
+      },
+      "day_water_usage": {
+        "name": "Daily water usage"
+      },
+      "flow_velocity": {
+        "name": "Flow rate"
+      },
+      "humidity": {
+        "name": "Humidity"
+      },
+      "low_battery": {
+        "name": "Low Battery"
+      },
+      "moisture": {
+        "name": "Moisture"
+      },
+      "work_state": {
+        "name": "Work state"
+      },
+      "residual_electricity": {
+        "name": "Battery"
+      },
+      "signal_strength": {
+        "name": "Signal strength"
+      },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "time_left": {
+        "name": "Remaining irrigation time"
+      },
+      "total_usage_after_reset": {
+        "name": "Total usage after reset"
+      },
+      "use_time_z1": {
+        "name": "Last irrigation time - Zone 1"
+      },
+      "use_time_z2": {
+        "name": "Last irrigation time - Zone 2"
+      },
+      "use_time": {
+        "name": "Accumulated use time"
+      },
+      "use_time_one": {
+        "name": "Last irrigation time"
+      },
+      "water_intake": {
+        "name": "Water intake"
+      },
+      "water_once": {
+        "name": "Last session water usage"
+      },
+      "water_use_data": {
+        "name": "Total water usage"
+      },
+      "wrong_finger": {
+        "name": "Wrong Fingerprint"
+      },
+      "wrong_password": {
+        "name": "Wrong Password"
+      },
+      "unlock_fingerprint": {
+        "name": "Last used Fingerprint"
+      },
+      "unlock_card": {
+        "name": "Last used Card"
+      },
+      "unlock_password": {
+        "name": "Last used Password"
+      },
+      "unlock_key": {
+        "name": "Last used Key"
+      },
+      "unlock_dynamic": {
+        "name": "Last used Dynamic Password"
+      },
+      "unlock_ble": {
+        "name": "Last used Bluetooth"
+      },
+      "unlock_phone_remote": {
+        "name": "Last used remote phone"
+      },
+      "weather_delay_remaining": {
+        "name": "Weather delay remaining"
+      },
+      "weather": {
+        "name": "Weather",
+        "state": {
+          "sunny": "Sunny",
+          "cloudy": "Cloudy",
+          "rainy": "Rainy",
+          "snowy": "Snowy",
+          "null": "Unavailable"
+        }
+      },
+      "spray_time_z1": {
+        "name": "Spray duration - Zone 1"
+      },
+      "spray_time_z2": {
+        "name": "Spray duration - Zone 2"
+      },
+      "work_state_z1": {
+        "name": "Work state - Zone 1",
+        "state": {
+          "idle": "Idle",
+          "manual": "Manual",
+          "spray": "Spray",
+          "timing": "Scheduled"
+        }
+      },
+      "work_state_z2": {
+        "name": "Work state - Zone 2",
+        "state": {
+          "idle": "Idle",
+          "manual": "Manual",
+          "spray": "Spray",
+          "timing": "Scheduled"
+        }
+      }
+    },
+    "switch": {
+      "automatic_lock": {
+        "name": "Automatic lock"
+      },
+      "antifreeze": {
+        "name": "Antifreeze"
+      },
+      "carbon_dioxide_alarm_switch": {
+        "name": "Alarm enabled"
+      },
+      "carbon_dioxide_severely_exceed_alarm": {
+        "name": "Severely exceed alarm"
+      },
+      "child_lock": {
+        "name": "Child Lock"
+      },
+      "lock_motor_state": {
+        "name": "Motor State"
+      },
+      "low_battery_alarm": {
+        "name": "Low battery alarm"
+      },
+      "manual_control": {
+        "name": "Manual control"
+      },
+      "program": {
+        "name": "Program"
+      },
+      "program_repeat_forever": {
+        "name": "Repeat forever"
+      },
+      "programming_mode": {
+        "name": "Programming Mode"
+      },
+      "programming_switch": {
+        "name": "Programming Switch"
+      },
+      "reverse_positions": {
+        "name": "Reverse positions"
+      },
+      "switch": {
+        "name": "Switch"
+      },
+      "water_scale_proof": {
+        "name": "Anti-scale"
+      },
+      "water_valve": {
+        "name": "Irrigation valve"
+      },
+      "water_valve_z1": {
+        "name": "Irrigation valve - Zone 1"
+      },
+      "water_valve_z2": {
+        "name": "Irrigation valve - Zone 2"
+      },
+      "weather_switch": {
+        "name": "Weather switch"
+      },
+      "window_check": {
+        "name": "Window Check"
+      },
+      "window_cleaner_switch": {
+        "name": "Cleaning"
+      },
+      "water_auto": {
+        "name": "Auto water spray"
+      }
+    },
+    "text": {
+      "program": {
+        "name": "Program: position[/time];..."
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "Window Cleaner"
+      },
+      "clean_time": {
+        "name": "Clean time"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_registered": "Device is not registered in Tuya cloud",
+      "invalid_auth": "Invalid authentication",
+      "login_error": "Login error ({code}): {msg}"
+    },
+    "step": {
+      "login": {
+        "data": {
+          "access_id": "Tuya IoT Access ID",
+          "access_secret": "Tuya IoT Access Secret",
+          "country_code": "Country",
+          "password": "Password",
+          "username": "Account"
+        },
+        "description": "Refer to documentation of Tuya integration to retrieve the cloud credentials {url}\n\nEnter your Tuya credentials."
+      }
+    }
+  }
 }

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -254,6 +254,23 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                 ),
                 TuyaBLEWaterValveWeatherSwitchMapping(dp_id=14),
             ],
+            "smd9kj1n": [  # HCT-626 Dual Water Timer
+                TuyaBLESwitchMapping(
+                    dp_id=1,
+                    description=SwitchEntityDescription(
+                        key="water_valve_z1",
+                        icon="mdi:valve",
+                    ),
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=2,
+                    description=SwitchEntityDescription(
+                        key="water_valve_z2",
+                        icon="mdi:valve",
+                    ),
+                ),
+                TuyaBLEWaterValveWeatherSwitchMapping(dp_id=43),
+            ],
             **dict.fromkeys(
                 ["nxquc5lb", "svhikeyq"],
                 [  # Smart water timer - SOP10

--- a/custom_components/tuya_ble/translations/de.json
+++ b/custom_components/tuya_ble/translations/de.json
@@ -1,384 +1,421 @@
 {
-    "config": {
-        "abort": {
-            "no_unconfigured_devices": "Keine unkonfigurierten Geräte gefunden."
-        },
-        "error": {
-            "device_not_registered": "Gerät ist nicht in der Tuya-Cloud registriert",
-            "invalid_auth": "Ungültige Authentifizierung",
-            "login_error": "Anmeldefehler ({code}): {msg}"
-        },
-        "flow_title": "{name}",
-        "step": {
-            "device": {
-                "data": {
-                    "address": "Tuya BLE-Gerät"
-                },
-                "description": "Wählen Sie das einzurichtende Tuya BLE-Gerät aus. Das Gerät muss über die mobile Anwendung in der Cloud registriert sein. Es wird empfohlen, das Gerät von einem eventuell vorhandenen Tuya Bluetooth-Gateway zu trennen."
-            },
-            "login": {
-                "data": {
-                    "access_id": "Tuya IoT Access ID",
-                    "access_secret": "Tuya IoT Access Secret",
-                    "country_code": "Land",
-                    "password": "Passwort",
-                    "username": "Konto"
-                },
-                "description": "Tuya BLE erfordert das Abrufen des Verschlüsselungsschlüssels aus der Tuya-Cloud. Fast alle Geräte müssen während der Einrichtung nur einmal auf die Cloud zugreifen.\n\nInformationen zum Abrufen der Cloud-Anmeldeinformationen finden Sie in der Dokumentation zur Tuya-Integration unter {url}\n\nGeben Sie Ihre Tuya-Zugangsdaten ein."
-            }
-        }
+  "config": {
+    "abort": {
+      "no_unconfigured_devices": "Keine unkonfigurierten Geräte gefunden."
     },
-    "entity": {
-        "binary_sensor": {
-            "fault": {
-                "name": "Fehler"
-            },
-            "lack_water": {
-                "name": "Wassermangel"
-            },
-            "low_battery": {
-                "name": "Batterie"
-            },
-            "lock_motor_state": {
-                "name": "Motorzustand"
-            },
-            "low_temp": {
-                "name": "Niedrige Temperatur"
-            },
-            "motor_fault": {
-                "name": "Motorfehler"
-            },
-            "sensor_fault": {
-                "name": "Sensorfehler"
-            }
-        },
-        "button": {
-            "push": {
-                "name": "Drücken"
-            },
-            "ble_unlock_check": {
-                "name": "Entriegeln"
-            },
-            "bluetooth_unlock": {
-                "name": "Entriegeln"
-            }
-        },
-        "event": {
-            "event": {
-                "name": "Ereignis"
-            }
-        },
-        "number": {
-            "ble_unlock_check": {
-                "name": "Entriegeln"
-            },
-            "brightness": {
-                "name": "Helligkeit"
-            },
-            "carbon_dioxide_alarm_level": {
-                "name": "Alarmstufe"
-            },
-            "countdown": {
-                "name": "Bewässerungsdauer"
-            },
-            "countdown_duration": {
-                "name": "Bewässerungsdauer"
-            },
-            "countdown_duration_z1": {
-                "name": "Bewässerungsdauer - Zone 1"
-            },
-            "countdown_duration_z2": {
-                "name": "Bewässerungsdauer - Zone 2"
-            },
-            "down_position": {
-                "name": "Untere Position"
-            },
-            "hold_time": {
-                "name": "Haltezeit"
-            },
-            "humidity_calibration": {
-                "name": "Luftfeuchtigkeitskalibrierung"
-            },
-            "program_idle_position": {
-                "name": "Ruheposition"
-            },
-            "program_repeats_count": {
-                "name": "Wiederholungsanzahl"
-            },
-            "recommended_water_intake": {
-                "name": "Empfohlene Wasseraufnahme"
-            },
-            "reporting_period": {
-                "name": "Berichtszeitraum"
-            },
-            "temperature_calibration": {
-                "name": "Temperaturkalibrierung"
-            },
-            "up_position": {
-                "name": "Obere Position"
-            }
-        },
-        "select": {
-            "beep_volume": {
-                "name": "Lautstärke sperren"
-            },
-            "language": {
-                "name": "Schloss-Sprache"
-            },
-            "fingerbot_mode": {
-                "name": "Modus",
-                "state": {
-                    "program": "Programm",
-                    "push": "Drücken",
-                    "switch": "Schalter"
-                }
-            },
-            "weather_delay": {
-                "name": "Wetterverzögerung"
-            },
-            "smart_weather": {
-                "name": "Intelligentes Wetter"
-            },
-            "reminder_mode": {
-                "name": "Erinnerungsmodus",
-                "state": {
-                    "interval_reminder": "Intervall",
-                    "schedule_reminder": "Zeitplan"
-                }
-            },
-            "temperature_unit": {
-                "name": "Temperatureinheit"
-            }
-        },
-        "sensor": {
-            "alarm_lock": {
-                "name": "Alarm",
-                "state": {
-                    "wrong_finger": "Falscher Fingerabdruck",
-                    "wrong_password": "Falsches Passwort",
-                    "low_battery": "Niedriger Batteriestatus",
-                    "power_off": "Ausgeschaltet"
-                }
-            },
-            "power_off": {
-                "name": "Ausgeschaltet"
-            },
-            "battery": {
-                "name": "Batterie"
-            },
-            "battery_charging": {
-                "name": "Batterieladung",
-                "state": {
-                    "charged": "Geladen",
-                    "charging": "Lädt",
-                    "not_charging": "Lädt nicht"
-                }
-            },
-            "battery_state": {
-                "name": "Batteriezustand",
-                "state": {
-                    "high": "Hoch",
-                    "low": "Niedrig",
-                    "middle": "Mittel",
-                    "normal": "Normal"
-                }
-            },
-            "carbon_dioxide": {
-                "name": "Kohlendioxid"
-            },
-            "carbon_dioxide_alarm": {
-                "name": "Kohlendioxidwert",
-                "state": {
-                    "alarm": "Alarm",
-                    "normal": "Normal"
-                }
-            },
-            "day_usage_after_reset": {
-                "name": "Täglicher Verbrauch nach Zurücksetzen"
-            },
-            "day_water_usage": {
-                "name": "Täglicher Wasserverbrauch"
-            },
-            "flow_velocity": {
-                "name": "Durchflussrate"
-            },
-            "lock_door_status": {
-                "name": "Türstatus",
-                "state": {
-                    "door_status_unknown": "Unbekannt",
-                    "door_status_open": "Offen",
-                    "door_status_closed": "Geschlossen"
-                }
-            },
-            "humidity": {
-                "name": "Luftfeuchtigkeit"
-            },
-            "low_battery": {
-                "name": "Niedriger Batteriestatus"
-            },
-            "moisture": {
-                "name": "Bodenfeuchtigkeit"
-            },
-            "work_state": {
-                "name": "Betriebszustand"
-            },
-            "residual_electricity": {
-                "name": "Batterie"
-            },
-            "signal_strength": {
-                "name": "Signalstärke"
-            },
-            "temperature": {
-                "name": "Temperatur"
-            },
-            "time_left": {
-                "name": "Verbleibende Bewässerungszeit"
-            },
-            "total_usage_after_reset": {
-                "name": "Gesamtverbrauch nach Zurücksetzen"
-            },
-            "use_time_z1": {
-                "name": "Letzte Bewässerungszeit - Zone 1"
-            },
-            "use_time_z2": {
-                "name": "Letzte Bewässerungszeit - Zone 2"
-            },
-            "use_time": {
-                "name": "Akkumulierte Nutzungszeit"
-            },
-            "use_time_one": {
-                "name": "Letzte Bewässerungszeit"
-            },
-            "water_intake": {
-                "name": "Wasseraufnahme"
-            },
-            "water_once": {
-                "name": "Wasserverbrauch der letzten Sitzung"
-            },
-            "water_use_data": {
-                "name": "Gesamter Wasserverbrauch"
-            },
-            "wrong_finger": {
-                "name": "Falscher Fingerabdruck"
-            },
-            "wrong_password": {
-                "name": "Falsches Passwort"
-            },
-            "unlock_fingerprint": {
-                "name": "Zuletzt verwendeter Fingerabdruck"
-            },
-            "unlock_card": {
-                "name": "Zuletzt verwendete Karte"
-            },
-            "unlock_password": {
-                "name": "Zuletzt verwendetes Passwort"
-            },
-            "unlock_key": {
-                "name": "Zuletzt verwendeter Schlüssel"
-            },
-            "unlock_dynamic": {
-                "name": "Zuletzt verwendetes dynamisches Passwort"
-            },
-            "unlock_ble": {
-                "name": "Zuletzt verwendetes Bluetooth"
-            },
-            "unlock_app": {
-                "name": "Zuletzt verwendete App"
-            },
-            "unlock_voice": {
-                "name": "Zuletzt verwendete Sprachsteuerung"
-            },
-            "unlock_temp_pwd": {
-                "name": "Zuletzt verwendetes temporäres Passwort"
-            }
-        },
-        "switch": {
-            "antifreeze": {
-                "name": "Frostschutz"
-            },
-            "carbon_dioxide_alarm_switch": {
-                "name": "Alarm aktiviert"
-            },
-            "carbon_dioxide_severely_exceed_alarm": {
-                "name": "Kritischer Grenzwert-Alarm"
-            },
-            "child_lock": {
-                "name": "Kindersicherung"
-            },
-            "lock_motor_state": {
-                "name": "Motorzustand"
-            },
-            "low_battery_alarm": {
-                "name": "Niedriger Batteriestatus-Alarm"
-            },
-            "manual_control": {
-                "name": "Manuelle Steuerung"
-            },
-            "program": {
-                "name": "Programm"
-            },
-            "program_repeat_forever": {
-                "name": "Endlos wiederholen"
-            },
-            "programming_mode": {
-                "name": "Programmiermodus"
-            },
-            "programming_switch": {
-                "name": "Programmierschalter"
-            },
-            "reverse_positions": {
-                "name": "Positionen umkehren"
-            },
-            "switch": {
-                "name": "Schalter"
-            },
-            "water_scale_proof": {
-                "name": "Antikalkschutz"
-            },
-            "water_valve": {
-                "name": "Bewässerungsventil"
-            },
-            "water_valve_z1": {
-                "name": "Bewässerungsventil - Zone 1"
-            },
-            "water_valve_z2": {
-                "name": "Bewässerungsventil - Zone 2"
-            },
-            "weather_switch": {
-                "name": "Wetterschalter"
-            },
-            "window_check": {
-                "name": "Fensterprüfung"
-            }
-        },
-        "text": {
-            "program": {
-                "name": "Programm: Position[/Zeit];..."
-            }
-        },
-        "vacuum": {
-            "vacuum": {
-                "name": "Fensterreiniger"
-            }
-        }
+    "error": {
+      "device_not_registered": "Gerät ist nicht in der Tuya-Cloud registriert",
+      "invalid_auth": "Ungültige Authentifizierung",
+      "login_error": "Anmeldefehler ({code}): {msg}"
     },
-    "options": {
-        "error": {
-            "device_not_registered": "Gerät ist nicht in der Tuya-Cloud registriert",
-            "invalid_auth": "Ungültige Authentifizierung",
-            "login_error": "Anmeldefehler ({code}): {msg}"
+    "flow_title": "{name}",
+    "step": {
+      "device": {
+        "data": {
+          "address": "Tuya BLE-Gerät"
         },
-        "step": {
-            "login": {
-                "data": {
-                    "access_id": "Tuya IoT Access ID",
-                    "access_secret": "Tuya IoT Access Secret",
-                    "country_code": "Land",
-                    "password": "Passwort",
-                    "username": "Konto"
-                },
-                "description": "Informationen zum Abrufen der Cloud-Anmeldeinformationen finden Sie in der Dokumentation zur Tuya-Integration unter {url}\n\nGeben Sie Ihre Tuya-Zugangsdaten ein."
-            }
-        }
+        "description": "Wählen Sie das einzurichtende Tuya BLE-Gerät aus. Das Gerät muss über die mobile Anwendung in der Cloud registriert sein. Es wird empfohlen, das Gerät von einem eventuell vorhandenen Tuya Bluetooth-Gateway zu trennen."
+      },
+      "login": {
+        "data": {
+          "access_id": "Tuya IoT Access ID",
+          "access_secret": "Tuya IoT Access Secret",
+          "country_code": "Land",
+          "password": "Passwort",
+          "username": "Konto"
+        },
+        "description": "Tuya BLE erfordert das Abrufen des Verschlüsselungsschlüssels aus der Tuya-Cloud. Fast alle Geräte müssen während der Einrichtung nur einmal auf die Cloud zugreifen.\n\nInformationen zum Abrufen der Cloud-Anmeldeinformationen finden Sie in der Dokumentation zur Tuya-Integration unter {url}\n\nGeben Sie Ihre Tuya-Zugangsdaten ein."
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "fault": {
+        "name": "Fehler"
+      },
+      "lack_water": {
+        "name": "Wassermangel"
+      },
+      "low_battery": {
+        "name": "Batterie"
+      },
+      "lock_motor_state": {
+        "name": "Motorzustand"
+      },
+      "low_temp": {
+        "name": "Niedrige Temperatur"
+      },
+      "motor_fault": {
+        "name": "Motorfehler"
+      },
+      "sensor_fault": {
+        "name": "Sensorfehler"
+      }
+    },
+    "button": {
+      "push": {
+        "name": "Drücken"
+      },
+      "ble_unlock_check": {
+        "name": "Entriegeln"
+      },
+      "bluetooth_unlock": {
+        "name": "Entriegeln"
+      }
+    },
+    "event": {
+      "event": {
+        "name": "Ereignis"
+      }
+    },
+    "number": {
+      "ble_unlock_check": {
+        "name": "Entriegeln"
+      },
+      "brightness": {
+        "name": "Helligkeit"
+      },
+      "carbon_dioxide_alarm_level": {
+        "name": "Alarmstufe"
+      },
+      "countdown": {
+        "name": "Bewässerungsdauer"
+      },
+      "countdown_duration": {
+        "name": "Bewässerungsdauer"
+      },
+      "countdown_duration_z1": {
+        "name": "Bewässerungsdauer - Zone 1"
+      },
+      "countdown_duration_z2": {
+        "name": "Bewässerungsdauer - Zone 2"
+      },
+      "down_position": {
+        "name": "Untere Position"
+      },
+      "hold_time": {
+        "name": "Haltezeit"
+      },
+      "humidity_calibration": {
+        "name": "Luftfeuchtigkeitskalibrierung"
+      },
+      "program_idle_position": {
+        "name": "Ruheposition"
+      },
+      "program_repeats_count": {
+        "name": "Wiederholungsanzahl"
+      },
+      "recommended_water_intake": {
+        "name": "Empfohlene Wasseraufnahme"
+      },
+      "reporting_period": {
+        "name": "Berichtszeitraum"
+      },
+      "temperature_calibration": {
+        "name": "Temperaturkalibrierung"
+      },
+      "up_position": {
+        "name": "Obere Position"
+      }
+    },
+    "select": {
+      "beep_volume": {
+        "name": "Lautstärke sperren"
+      },
+      "language": {
+        "name": "Schloss-Sprache"
+      },
+      "fingerbot_mode": {
+        "name": "Modus",
+        "state": {
+          "program": "Programm",
+          "push": "Drücken",
+          "switch": "Schalter"
+        }
+      },
+      "weather_delay": {
+        "name": "Wetterverzögerung"
+      },
+      "smart_weather": {
+        "name": "Intelligentes Wetter"
+      },
+      "reminder_mode": {
+        "name": "Erinnerungsmodus",
+        "state": {
+          "interval_reminder": "Intervall",
+          "schedule_reminder": "Zeitplan"
+        }
+      },
+      "temperature_unit": {
+        "name": "Temperatureinheit"
+      }
+    },
+    "sensor": {
+      "alarm_lock": {
+        "name": "Alarm",
+        "state": {
+          "wrong_finger": "Falscher Fingerabdruck",
+          "wrong_password": "Falsches Passwort",
+          "low_battery": "Niedriger Batteriestatus",
+          "power_off": "Ausgeschaltet"
+        }
+      },
+      "power_off": {
+        "name": "Ausgeschaltet"
+      },
+      "battery": {
+        "name": "Batterie"
+      },
+      "battery_charging": {
+        "name": "Batterieladung",
+        "state": {
+          "charged": "Geladen",
+          "charging": "Lädt",
+          "not_charging": "Lädt nicht"
+        }
+      },
+      "battery_state": {
+        "name": "Batteriezustand",
+        "state": {
+          "high": "Hoch",
+          "low": "Niedrig",
+          "middle": "Mittel",
+          "normal": "Normal"
+        }
+      },
+      "carbon_dioxide": {
+        "name": "Kohlendioxid"
+      },
+      "carbon_dioxide_alarm": {
+        "name": "Kohlendioxidwert",
+        "state": {
+          "alarm": "Alarm",
+          "normal": "Normal"
+        }
+      },
+      "day_usage_after_reset": {
+        "name": "Täglicher Verbrauch nach Zurücksetzen"
+      },
+      "day_water_usage": {
+        "name": "Täglicher Wasserverbrauch"
+      },
+      "flow_velocity": {
+        "name": "Durchflussrate"
+      },
+      "lock_door_status": {
+        "name": "Türstatus",
+        "state": {
+          "door_status_unknown": "Unbekannt",
+          "door_status_open": "Offen",
+          "door_status_closed": "Geschlossen"
+        }
+      },
+      "humidity": {
+        "name": "Luftfeuchtigkeit"
+      },
+      "low_battery": {
+        "name": "Niedriger Batteriestatus"
+      },
+      "moisture": {
+        "name": "Bodenfeuchtigkeit"
+      },
+      "work_state": {
+        "name": "Betriebszustand"
+      },
+      "residual_electricity": {
+        "name": "Batterie"
+      },
+      "signal_strength": {
+        "name": "Signalstärke"
+      },
+      "temperature": {
+        "name": "Temperatur"
+      },
+      "time_left": {
+        "name": "Verbleibende Bewässerungszeit"
+      },
+      "total_usage_after_reset": {
+        "name": "Gesamtverbrauch nach Zurücksetzen"
+      },
+      "use_time_z1": {
+        "name": "Letzte Bewässerungszeit - Zone 1"
+      },
+      "use_time_z2": {
+        "name": "Letzte Bewässerungszeit - Zone 2"
+      },
+      "use_time": {
+        "name": "Akkumulierte Nutzungszeit"
+      },
+      "use_time_one": {
+        "name": "Letzte Bewässerungszeit"
+      },
+      "water_intake": {
+        "name": "Wasseraufnahme"
+      },
+      "water_once": {
+        "name": "Wasserverbrauch der letzten Sitzung"
+      },
+      "water_use_data": {
+        "name": "Gesamter Wasserverbrauch"
+      },
+      "wrong_finger": {
+        "name": "Falscher Fingerabdruck"
+      },
+      "wrong_password": {
+        "name": "Falsches Passwort"
+      },
+      "unlock_fingerprint": {
+        "name": "Zuletzt verwendeter Fingerabdruck"
+      },
+      "unlock_card": {
+        "name": "Zuletzt verwendete Karte"
+      },
+      "unlock_password": {
+        "name": "Zuletzt verwendetes Passwort"
+      },
+      "unlock_key": {
+        "name": "Zuletzt verwendeter Schlüssel"
+      },
+      "unlock_dynamic": {
+        "name": "Zuletzt verwendetes dynamisches Passwort"
+      },
+      "unlock_ble": {
+        "name": "Zuletzt verwendetes Bluetooth"
+      },
+      "unlock_app": {
+        "name": "Zuletzt verwendete App"
+      },
+      "unlock_voice": {
+        "name": "Zuletzt verwendete Sprachsteuerung"
+      },
+      "unlock_temp_pwd": {
+        "name": "Zuletzt verwendetes temporäres Passwort"
+      },
+      "weather_delay_remaining": {
+        "name": "Verbleibende Wetterverzögerung"
+      },
+      "weather": {
+        "name": "Wetter",
+        "state": {
+          "sunny": "Sonnig",
+          "cloudy": "Bewölkt",
+          "rainy": "Regnerisch",
+          "snowy": "Verschneit",
+          "null": "Nicht verfügbar"
+        }
+      },
+      "spray_time_z1": {
+        "name": "Sprühdauer - Zone 1"
+      },
+      "spray_time_z2": {
+        "name": "Sprühdauer - Zone 2"
+      },
+      "work_state_z1": {
+        "name": "Arbeitsstatus - Zone 1",
+        "state": {
+          "idle": "Leerlauf",
+          "manual": "Manuell",
+          "spray": "Sprühen",
+          "timing": "Geplant"
+        }
+      },
+      "work_state_z2": {
+        "name": "Arbeitsstatus - Zone 2",
+        "state": {
+          "idle": "Leerlauf",
+          "manual": "Manuell",
+          "spray": "Sprühen",
+          "timing": "Geplant"
+        }
+      }
+    },
+    "switch": {
+      "antifreeze": {
+        "name": "Frostschutz"
+      },
+      "carbon_dioxide_alarm_switch": {
+        "name": "Alarm aktiviert"
+      },
+      "carbon_dioxide_severely_exceed_alarm": {
+        "name": "Kritischer Grenzwert-Alarm"
+      },
+      "child_lock": {
+        "name": "Kindersicherung"
+      },
+      "lock_motor_state": {
+        "name": "Motorzustand"
+      },
+      "low_battery_alarm": {
+        "name": "Niedriger Batteriestatus-Alarm"
+      },
+      "manual_control": {
+        "name": "Manuelle Steuerung"
+      },
+      "program": {
+        "name": "Programm"
+      },
+      "program_repeat_forever": {
+        "name": "Endlos wiederholen"
+      },
+      "programming_mode": {
+        "name": "Programmiermodus"
+      },
+      "programming_switch": {
+        "name": "Programmierschalter"
+      },
+      "reverse_positions": {
+        "name": "Positionen umkehren"
+      },
+      "switch": {
+        "name": "Schalter"
+      },
+      "water_scale_proof": {
+        "name": "Antikalkschutz"
+      },
+      "water_valve": {
+        "name": "Bewässerungsventil"
+      },
+      "water_valve_z1": {
+        "name": "Bewässerungsventil - Zone 1"
+      },
+      "water_valve_z2": {
+        "name": "Bewässerungsventil - Zone 2"
+      },
+      "weather_switch": {
+        "name": "Wetterschalter"
+      },
+      "window_check": {
+        "name": "Fensterprüfung"
+      }
+    },
+    "text": {
+      "program": {
+        "name": "Programm: Position[/Zeit];..."
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "Fensterreiniger"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_registered": "Gerät ist nicht in der Tuya-Cloud registriert",
+      "invalid_auth": "Ungültige Authentifizierung",
+      "login_error": "Anmeldefehler ({code}): {msg}"
+    },
+    "step": {
+      "login": {
+        "data": {
+          "access_id": "Tuya IoT Access ID",
+          "access_secret": "Tuya IoT Access Secret",
+          "country_code": "Land",
+          "password": "Passwort",
+          "username": "Konto"
+        },
+        "description": "Informationen zum Abrufen der Cloud-Anmeldeinformationen finden Sie in der Dokumentation zur Tuya-Integration unter {url}\n\nGeben Sie Ihre Tuya-Zugangsdaten ein."
+      }
+    }
+  }
 }

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -1,416 +1,453 @@
 {
-    "config": {
-        "abort": {
-            "no_unconfigured_devices": "No unconfigured devices found."
-        },
-        "error": {
-            "device_not_registered": "Device is not registered in Tuya cloud",
-            "invalid_auth": "Invalid authentication",
-            "login_error": "Login error ({code}): {msg}"
-        },
-        "flow_title": "{name}",
-        "step": {
-            "device": {
-                "data": {
-                    "address": "Tuya BLE device"
-                },
-                "description": "Select Tuya BLE device to setup. Device must be registered in the cloud using the mobile application. It's better to unbind the device from Tuya Bluetooth gateway, if any."
-            },
-            "login": {
-                "data": {
-                    "access_id": "Tuya IoT Access ID",
-                    "access_secret": "Tuya IoT Access Secret",
-                    "country_code": "Country",
-                    "password": "Password",
-                    "username": "Account"
-                },
-                "description": "Tuya BLE requires obtaining encryption key from Tuya cloud. Almost all devices only need to access the cloud once during setup.\n\nRefer to documentation of Tuya integration to retrieve the cloud credentials {url}\n\nEnter your Tuya credentials."
-            }
-        }
+  "config": {
+    "abort": {
+      "no_unconfigured_devices": "No unconfigured devices found."
     },
-    "entity": {
-        "binary_sensor": {
-            "fault": {
-                "name": "Fault"
-            },
-            "lack_water": {
-                "name": "Lack of water"
-            },
-            "low_battery": {
-                "name": "Battery"
-            },
-            "lock_motor_state": {
-                "name": "Motor State"
-            },
-            "low_temp": {
-                "name": "Low temperature"
-            },
-            "motor_fault": {
-                "name": "Motor fault"
-            },
-            "sensor_fault": {
-                "name": "Sensor fault"
-            }
-        },
-        "button": {
-            "push": {
-                "name": "Push"
-            },
-            "ble_unlock_check": {
-                "name": "Unlock"
-            },
-            "bluetooth_unlock": {
-                "name": "Unlock"
-            }
-        },
-        "event": {
-            "event": {
-                "name": "Event"
-            }
-        },
-        "number": {
-            "ble_unlock_check": {
-                "name": "Unlock"
-            },
-            "brightness": {
-                "name": "Brightness"
-            },
-            "carbon_dioxide_alarm_level": {
-                "name": "Alarm level"
-            },
-            "countdown": {
-                "name": "Irrigation duration"
-            },
-            "countdown_duration": {
-                "name": "Irrigation duration"
-            },
-            "countdown_duration_z1": {
-                "name": "Irrigation duration - Zone 1"
-            },
-            "countdown_duration_z2": {
-                "name": "Irrigation duration - Zone 2"
-            },
-            "down_position": {
-                "name": "Down position"
-            },
-            "hold_time": {
-                "name": "Hold time"
-            },
-            "humidity_calibration": {
-                "name": "Humidity calibration"
-            },
-            "program_idle_position": {
-                "name": "Idle position"
-            },
-            "program_repeats_count": {
-                "name": "Repeats count"
-            },
-            "recommended_water_intake": {
-                "name": "Recommended water intake"
-            },
-            "reporting_period": {
-                "name": "Reporting period"
-            },
-            "temperature_calibration": {
-                "name": "Temperature calibration"
-            },
-            "up_position": {
-                "name": "Up position"
-            }
-        },
-        "select": {
-            "beep_volume": {
-                "name": "Lock Volume"
-            },
-            "language": {
-                "name": "Lock Language"
-            },
-            "fingerbot_mode": {
-                "name": "Mode",
-                "state": {
-                    "program": "Program",
-                    "push": "Push",
-                    "switch": "Switch"
-                }
-            },
-            "weather_delay": {
-                "name": "Weather delay"
-            },
-            "smart_weather": {
-                "name": "Smart weather"
-            },
-            "reminder_mode": {
-                "name": "Reminder mode",
-                "state": {
-                    "interval_reminder": "Interval",
-                    "schedule_reminder": "Schedule"
-                }
-            },
-            "temperature_unit": {
-                "name": "Temperature unit"
-            },
-            "mode": {
-                "name": "Cleaning mode",
-                "state": {
-                    "smart": "Smart",
-                    "z_mode": "Z-Mode",
-                    "n_mode": "N-Mode",
-                    "edge": "Edge",
-                    "spot": "Spot"
-                }
-            },
-            "direction_control": {
-                "name": "Direction",
-                "state": {
-                    "forward": "Forward",
-                    "backward": "Backward",
-                    "turn_left": "Turn left",
-                    "turn_right": "Turn right",
-                    "stop": "Stop"
-                }
-            }
-        },
-        "sensor": {
-            "alarm_lock": {
-                "name": "Alarm",
-                "state": {
-                    "wrong_finger": "Wrong Fingerprint",
-                    "wrong_password": "Wrong Password",
-                    "low_battery": "Low Battery",
-                    "power_off": "Power off"
-                }
-            },
-            "power_off": {
-                "name": "Power off"
-            },
-            "battery": {
-                "name": "Battery"
-            },
-            "battery_charging": {
-                "name": "Battery charging",
-                "state": {
-                    "charged": "Charged",
-                    "charging": "Charging",
-                    "not_charging": "Not charging"
-                }
-            },
-            "battery_state": {
-                "name": "Battery state",
-                "state": {
-                    "high": "High",
-                    "low": "Low",
-                    "middle": "Medium",
-                    "normal": "Normal"
-                }
-            },
-            "carbon_dioxide": {
-                "name": "Carbon dioxide"
-            },
-            "carbon_dioxide_alarm": {
-                "name": "Carbon dioxide level",
-                "state": {
-                    "alarm": "Alarm",
-                    "normal": "Normal"
-                }
-            },
-            "day_usage_after_reset": {
-                "name": "Daily usage after reset"
-            },
-            "day_water_usage": {
-                "name": "Daily water usage"
-            },
-            "flow_velocity": {
-                "name": "Flow rate"
-            },
-            "lock_door_status": {
-                "name": "Door status",
-                "state": {
-                    "door_status_unknown": "Unknown",
-                    "door_status_open": "Open",
-                    "door_status_closed": "Closed"
-                }
-            },
-            "humidity": {
-                "name": "Humidity"
-            },
-            "low_battery": {
-                "name": "Low Battery"
-            },
-            "moisture": {
-                "name": "Moisture"
-            },
-            "work_state": {
-                "name": "Work state"
-            },
-            "residual_electricity": {
-                "name": "Battery"
-            },
-            "signal_strength": {
-                "name": "Signal strength"
-            },
-            "temperature": {
-                "name": "Temperature"
-            },
-            "time_left": {
-                "name": "Remaining irrigation time"
-            },
-            "total_usage_after_reset": {
-                "name": "Total usage after reset"
-            },
-            "use_time_z1": {
-                "name": "Last irrigation time - Zone 1"
-            },
-            "use_time_z2": {
-                "name": "Last irrigation time - Zone 2"
-            },
-            "use_time": {
-                "name": "Accumulated use time"
-            },
-            "use_time_one": {
-                "name": "Last irrigation time"
-            },
-            "water_intake": {
-                "name": "Water intake"
-            },
-            "water_once": {
-                "name": "Last session water usage"
-            },
-            "water_use_data": {
-                "name": "Total water usage"
-            },
-            "wrong_finger": {
-                "name": "Wrong Fingerprint"
-            },
-            "wrong_password": {
-                "name": "Wrong Password"
-            },
-            "unlock_fingerprint": {
-                "name": "Last used Fingerprint"
-            },
-            "unlock_card": {
-                "name": "Last used Card"
-            },
-            "unlock_password": {
-                "name": "Last used Password"
-            },
-            "unlock_key": {
-                "name": "Last used Key"
-            },
-            "unlock_dynamic": {
-                "name": "Last used Dynamic Password"
-            },
-            "unlock_ble": {
-                "name": "Last used Bluetooth"
-            },
-            "unlock_app": {
-                "name": "Last used App"
-            },
-            "unlock_voice": {
-                "name": "Last used Voice"
-            },
-            "unlock_temp_pwd": {
-                "name": "Last used Temporary Password"
-            }
-        },
-        "switch": {
-            "automatic_lock": {
-                "name": "Automatic lock"
-            },
-            "antifreeze": {
-                "name": "Antifreeze"
-            },
-            "carbon_dioxide_alarm_switch": {
-                "name": "Alarm enabled"
-            },
-            "carbon_dioxide_severely_exceed_alarm": {
-                "name": "Severely exceed alarm"
-            },
-            "child_lock": {
-                "name": "Child Lock"
-            },
-            "lock_motor_state": {
-                "name": "Motor State"
-            },
-            "low_battery_alarm": {
-                "name": "Low battery alarm"
-            },
-            "manual_control": {
-                "name": "Manual control"
-            },
-            "program": {
-                "name": "Program"
-            },
-            "program_repeat_forever": {
-                "name": "Repeat forever"
-            },
-            "programming_mode": {
-                "name": "Programming Mode"
-            },
-            "programming_switch": {
-                "name": "Programming Switch"
-            },
-            "reverse_positions": {
-                "name": "Reverse positions"
-            },
-            "switch": {
-                "name": "Switch"
-            },
-            "water_scale_proof": {
-                "name": "Anti-scale"
-            },
-            "water_valve": {
-                "name": "Irrigation valve"
-            },
-            "water_valve_z1": {
-                "name": "Irrigation valve - Zone 1"
-            },
-            "water_valve_z2": {
-                "name": "Irrigation valve - Zone 2"
-            },
-            "weather_switch": {
-                "name": "Weather switch"
-            },
-            "window_check": {
-                "name": "Window Check"
-            },
-            "window_cleaner_switch": {
-                "name": "Cleaning"
-            },
-            "water_auto": {
-                "name": "Auto water spray"
-            }
-        },
-        "text": {
-            "program": {
-                "name": "Program: position[/time];..."
-            }
-        },
-        "vacuum": {
-            "vacuum": {
-                "name": "Window Cleaner"
-            },
-            "clean_time": {
-                "name": "Clean time"
-            }
-        }
+    "error": {
+      "device_not_registered": "Device is not registered in Tuya cloud",
+      "invalid_auth": "Invalid authentication",
+      "login_error": "Login error ({code}): {msg}"
     },
-    "options": {
-        "error": {
-            "device_not_registered": "Device is not registered in Tuya cloud",
-            "invalid_auth": "Invalid authentication",
-            "login_error": "Login error ({code}): {msg}"
+    "flow_title": "{name}",
+    "step": {
+      "device": {
+        "data": {
+          "address": "Tuya BLE device"
         },
-        "step": {
-            "login": {
-                "data": {
-                    "access_id": "Tuya IoT Access ID",
-                    "access_secret": "Tuya IoT Access Secret",
-                    "country_code": "Country",
-                    "password": "Password",
-                    "username": "Account"
-                },
-                "description": "Refer to documentation of Tuya integration to retrieve the cloud credentials {url}\n\nEnter your Tuya credentials."
-            }
-        }
+        "description": "Select Tuya BLE device to setup. Device must be registered in the cloud using the mobile application. It's better to unbind the device from Tuya Bluetooth gateway, if any."
+      },
+      "login": {
+        "data": {
+          "access_id": "Tuya IoT Access ID",
+          "access_secret": "Tuya IoT Access Secret",
+          "country_code": "Country",
+          "password": "Password",
+          "username": "Account"
+        },
+        "description": "Tuya BLE requires obtaining encryption key from Tuya cloud. Almost all devices only need to access the cloud once during setup.\n\nRefer to documentation of Tuya integration to retrieve the cloud credentials {url}\n\nEnter your Tuya credentials."
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "fault": {
+        "name": "Fault"
+      },
+      "lack_water": {
+        "name": "Lack of water"
+      },
+      "low_battery": {
+        "name": "Battery"
+      },
+      "lock_motor_state": {
+        "name": "Motor State"
+      },
+      "low_temp": {
+        "name": "Low temperature"
+      },
+      "motor_fault": {
+        "name": "Motor fault"
+      },
+      "sensor_fault": {
+        "name": "Sensor fault"
+      }
+    },
+    "button": {
+      "push": {
+        "name": "Push"
+      },
+      "ble_unlock_check": {
+        "name": "Unlock"
+      },
+      "bluetooth_unlock": {
+        "name": "Unlock"
+      }
+    },
+    "event": {
+      "event": {
+        "name": "Event"
+      }
+    },
+    "number": {
+      "ble_unlock_check": {
+        "name": "Unlock"
+      },
+      "brightness": {
+        "name": "Brightness"
+      },
+      "carbon_dioxide_alarm_level": {
+        "name": "Alarm level"
+      },
+      "countdown": {
+        "name": "Irrigation duration"
+      },
+      "countdown_duration": {
+        "name": "Irrigation duration"
+      },
+      "countdown_duration_z1": {
+        "name": "Irrigation duration - Zone 1"
+      },
+      "countdown_duration_z2": {
+        "name": "Irrigation duration - Zone 2"
+      },
+      "down_position": {
+        "name": "Down position"
+      },
+      "hold_time": {
+        "name": "Hold time"
+      },
+      "humidity_calibration": {
+        "name": "Humidity calibration"
+      },
+      "program_idle_position": {
+        "name": "Idle position"
+      },
+      "program_repeats_count": {
+        "name": "Repeats count"
+      },
+      "recommended_water_intake": {
+        "name": "Recommended water intake"
+      },
+      "reporting_period": {
+        "name": "Reporting period"
+      },
+      "temperature_calibration": {
+        "name": "Temperature calibration"
+      },
+      "up_position": {
+        "name": "Up position"
+      }
+    },
+    "select": {
+      "beep_volume": {
+        "name": "Lock Volume"
+      },
+      "language": {
+        "name": "Lock Language"
+      },
+      "fingerbot_mode": {
+        "name": "Mode",
+        "state": {
+          "program": "Program",
+          "push": "Push",
+          "switch": "Switch"
+        }
+      },
+      "weather_delay": {
+        "name": "Weather delay"
+      },
+      "smart_weather": {
+        "name": "Smart weather"
+      },
+      "reminder_mode": {
+        "name": "Reminder mode",
+        "state": {
+          "interval_reminder": "Interval",
+          "schedule_reminder": "Schedule"
+        }
+      },
+      "temperature_unit": {
+        "name": "Temperature unit"
+      },
+      "mode": {
+        "name": "Cleaning mode",
+        "state": {
+          "smart": "Smart",
+          "z_mode": "Z-Mode",
+          "n_mode": "N-Mode",
+          "edge": "Edge",
+          "spot": "Spot"
+        }
+      },
+      "direction_control": {
+        "name": "Direction",
+        "state": {
+          "forward": "Forward",
+          "backward": "Backward",
+          "turn_left": "Turn left",
+          "turn_right": "Turn right",
+          "stop": "Stop"
+        }
+      }
+    },
+    "sensor": {
+      "alarm_lock": {
+        "name": "Alarm",
+        "state": {
+          "wrong_finger": "Wrong Fingerprint",
+          "wrong_password": "Wrong Password",
+          "low_battery": "Low Battery",
+          "power_off": "Power off"
+        }
+      },
+      "power_off": {
+        "name": "Power off"
+      },
+      "battery": {
+        "name": "Battery"
+      },
+      "battery_charging": {
+        "name": "Battery charging",
+        "state": {
+          "charged": "Charged",
+          "charging": "Charging",
+          "not_charging": "Not charging"
+        }
+      },
+      "battery_state": {
+        "name": "Battery state",
+        "state": {
+          "high": "High",
+          "low": "Low",
+          "middle": "Medium",
+          "normal": "Normal"
+        }
+      },
+      "carbon_dioxide": {
+        "name": "Carbon dioxide"
+      },
+      "carbon_dioxide_alarm": {
+        "name": "Carbon dioxide level",
+        "state": {
+          "alarm": "Alarm",
+          "normal": "Normal"
+        }
+      },
+      "day_usage_after_reset": {
+        "name": "Daily usage after reset"
+      },
+      "day_water_usage": {
+        "name": "Daily water usage"
+      },
+      "flow_velocity": {
+        "name": "Flow rate"
+      },
+      "lock_door_status": {
+        "name": "Door status",
+        "state": {
+          "door_status_unknown": "Unknown",
+          "door_status_open": "Open",
+          "door_status_closed": "Closed"
+        }
+      },
+      "humidity": {
+        "name": "Humidity"
+      },
+      "low_battery": {
+        "name": "Low Battery"
+      },
+      "moisture": {
+        "name": "Moisture"
+      },
+      "work_state": {
+        "name": "Work state"
+      },
+      "residual_electricity": {
+        "name": "Battery"
+      },
+      "signal_strength": {
+        "name": "Signal strength"
+      },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "time_left": {
+        "name": "Remaining irrigation time"
+      },
+      "total_usage_after_reset": {
+        "name": "Total usage after reset"
+      },
+      "use_time_z1": {
+        "name": "Last irrigation time - Zone 1"
+      },
+      "use_time_z2": {
+        "name": "Last irrigation time - Zone 2"
+      },
+      "use_time": {
+        "name": "Accumulated use time"
+      },
+      "use_time_one": {
+        "name": "Last irrigation time"
+      },
+      "water_intake": {
+        "name": "Water intake"
+      },
+      "water_once": {
+        "name": "Last session water usage"
+      },
+      "water_use_data": {
+        "name": "Total water usage"
+      },
+      "wrong_finger": {
+        "name": "Wrong Fingerprint"
+      },
+      "wrong_password": {
+        "name": "Wrong Password"
+      },
+      "unlock_fingerprint": {
+        "name": "Last used Fingerprint"
+      },
+      "unlock_card": {
+        "name": "Last used Card"
+      },
+      "unlock_password": {
+        "name": "Last used Password"
+      },
+      "unlock_key": {
+        "name": "Last used Key"
+      },
+      "unlock_dynamic": {
+        "name": "Last used Dynamic Password"
+      },
+      "unlock_ble": {
+        "name": "Last used Bluetooth"
+      },
+      "unlock_app": {
+        "name": "Last used App"
+      },
+      "unlock_voice": {
+        "name": "Last used Voice"
+      },
+      "unlock_temp_pwd": {
+        "name": "Last used Temporary Password"
+      },
+      "weather_delay_remaining": {
+        "name": "Weather delay remaining"
+      },
+      "weather": {
+        "name": "Weather",
+        "state": {
+          "sunny": "Sunny",
+          "cloudy": "Cloudy",
+          "rainy": "Rainy",
+          "snowy": "Snowy",
+          "null": "Unavailable"
+        }
+      },
+      "spray_time_z1": {
+        "name": "Spray duration - Zone 1"
+      },
+      "spray_time_z2": {
+        "name": "Spray duration - Zone 2"
+      },
+      "work_state_z1": {
+        "name": "Work state - Zone 1",
+        "state": {
+          "idle": "Idle",
+          "manual": "Manual",
+          "spray": "Spray",
+          "timing": "Scheduled"
+        }
+      },
+      "work_state_z2": {
+        "name": "Work state - Zone 2",
+        "state": {
+          "idle": "Idle",
+          "manual": "Manual",
+          "spray": "Spray",
+          "timing": "Scheduled"
+        }
+      }
+    },
+    "switch": {
+      "automatic_lock": {
+        "name": "Automatic lock"
+      },
+      "antifreeze": {
+        "name": "Antifreeze"
+      },
+      "carbon_dioxide_alarm_switch": {
+        "name": "Alarm enabled"
+      },
+      "carbon_dioxide_severely_exceed_alarm": {
+        "name": "Severely exceed alarm"
+      },
+      "child_lock": {
+        "name": "Child Lock"
+      },
+      "lock_motor_state": {
+        "name": "Motor State"
+      },
+      "low_battery_alarm": {
+        "name": "Low battery alarm"
+      },
+      "manual_control": {
+        "name": "Manual control"
+      },
+      "program": {
+        "name": "Program"
+      },
+      "program_repeat_forever": {
+        "name": "Repeat forever"
+      },
+      "programming_mode": {
+        "name": "Programming Mode"
+      },
+      "programming_switch": {
+        "name": "Programming Switch"
+      },
+      "reverse_positions": {
+        "name": "Reverse positions"
+      },
+      "switch": {
+        "name": "Switch"
+      },
+      "water_scale_proof": {
+        "name": "Anti-scale"
+      },
+      "water_valve": {
+        "name": "Irrigation valve"
+      },
+      "water_valve_z1": {
+        "name": "Irrigation valve - Zone 1"
+      },
+      "water_valve_z2": {
+        "name": "Irrigation valve - Zone 2"
+      },
+      "weather_switch": {
+        "name": "Weather switch"
+      },
+      "window_check": {
+        "name": "Window Check"
+      },
+      "window_cleaner_switch": {
+        "name": "Cleaning"
+      },
+      "water_auto": {
+        "name": "Auto water spray"
+      }
+    },
+    "text": {
+      "program": {
+        "name": "Program: position[/time];..."
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "Window Cleaner"
+      },
+      "clean_time": {
+        "name": "Clean time"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_registered": "Device is not registered in Tuya cloud",
+      "invalid_auth": "Invalid authentication",
+      "login_error": "Login error ({code}): {msg}"
+    },
+    "step": {
+      "login": {
+        "data": {
+          "access_id": "Tuya IoT Access ID",
+          "access_secret": "Tuya IoT Access Secret",
+          "country_code": "Country",
+          "password": "Password",
+          "username": "Account"
+        },
+        "description": "Refer to documentation of Tuya integration to retrieve the cloud credentials {url}\n\nEnter your Tuya credentials."
+      }
+    }
+  }
 }

--- a/custom_components/tuya_ble/translations/es.json
+++ b/custom_components/tuya_ble/translations/es.json
@@ -1,384 +1,421 @@
 {
-    "config": {
-        "abort": {
-            "no_unconfigured_devices": "No se encontraron dispositivos sin configurar."
-        },
-        "error": {
-            "device_not_registered": "El dispositivo no está registrado en la nube de Tuya",
-            "invalid_auth": "Autenticación inválida",
-            "login_error": "Error de inicio de sesión ({code}): {msg}"
-        },
-        "flow_title": "{name}",
-        "step": {
-            "device": {
-                "data": {
-                    "address": "Dispositivo Tuya BLE"
-                },
-                "description": "Seleccione el dispositivo Tuya BLE para configurar. El dispositivo debe estar registrado en la nube mediante la aplicación móvil. Se recomienda desvincular el dispositivo de cualquier puerta de enlace Bluetooth de Tuya."
-            },
-            "login": {
-                "data": {
-                    "access_id": "ID de acceso de Tuya IoT",
-                    "access_secret": "Clave secreta de Tuya IoT",
-                    "country_code": "País",
-                    "password": "Contraseña",
-                    "username": "Cuenta"
-                },
-                "description": "Tuya BLE requiere obtener la clave de cifrado de la nube de Tuya. Casi todos los dispositivos solo necesitan acceder a la nube una vez durante la configuración.\n\nConsulte la documentación de la integración de Tuya para obtener las credenciales de la nube {url}\n\nIntroduzca sus credenciales de Tuya."
-            }
-        }
+  "config": {
+    "abort": {
+      "no_unconfigured_devices": "No se encontraron dispositivos sin configurar."
     },
-    "entity": {
-        "binary_sensor": {
-            "fault": {
-                "name": "Fallo"
-            },
-            "lack_water": {
-                "name": "Falta de agua"
-            },
-            "low_battery": {
-                "name": "Batería"
-            },
-            "lock_motor_state": {
-                "name": "Estado del motor"
-            },
-            "low_temp": {
-                "name": "Baja temperatura"
-            },
-            "motor_fault": {
-                "name": "Fallo del motor"
-            },
-            "sensor_fault": {
-                "name": "Fallo del sensor"
-            }
-        },
-        "button": {
-            "push": {
-                "name": "Pulsar"
-            },
-            "ble_unlock_check": {
-                "name": "Desbloquear"
-            },
-            "bluetooth_unlock": {
-                "name": "Desbloquear"
-            }
-        },
-        "event": {
-            "event": {
-                "name": "Evento"
-            }
-        },
-        "number": {
-            "ble_unlock_check": {
-                "name": "Desbloquear"
-            },
-            "brightness": {
-                "name": "Brillo"
-            },
-            "carbon_dioxide_alarm_level": {
-                "name": "Nivel de alarma"
-            },
-            "countdown": {
-                "name": "Duración del riego"
-            },
-            "countdown_duration": {
-                "name": "Duración del riego"
-            },
-            "countdown_duration_z1": {
-                "name": "Duración del riego - Zona 1"
-            },
-            "countdown_duration_z2": {
-                "name": "Duración del riego - Zona 2"
-            },
-            "down_position": {
-                "name": "Posición abajo"
-            },
-            "hold_time": {
-                "name": "Tiempo de espera"
-            },
-            "humidity_calibration": {
-                "name": "Calibración de humedad"
-            },
-            "program_idle_position": {
-                "name": "Posición de reposo"
-            },
-            "program_repeats_count": {
-                "name": "Número de repeticiones"
-            },
-            "recommended_water_intake": {
-                "name": "Consumo de agua recomendado"
-            },
-            "reporting_period": {
-                "name": "Período de reporte"
-            },
-            "temperature_calibration": {
-                "name": "Calibración de temperatura"
-            },
-            "up_position": {
-                "name": "Posición arriba"
-            }
-        },
-        "select": {
-            "beep_volume": {
-                "name": "Volumen de la cerradura"
-            },
-            "language": {
-                "name": "Idioma de la cerradura"
-            },
-            "fingerbot_mode": {
-                "name": "Modo",
-                "state": {
-                    "program": "Programa",
-                    "push": "Pulsar",
-                    "switch": "Interruptor"
-                }
-            },
-            "weather_delay": {
-                "name": "Retraso meteorológico"
-            },
-            "smart_weather": {
-                "name": "Clima inteligente"
-            },
-            "reminder_mode": {
-                "name": "Modo de recordatorio",
-                "state": {
-                    "interval_reminder": "Intervalo",
-                    "schedule_reminder": "Programación"
-                }
-            },
-            "temperature_unit": {
-                "name": "Unidad de temperatura"
-            }
-        },
-        "sensor": {
-            "alarm_lock": {
-                "name": "Alarma",
-                "state": {
-                    "wrong_finger": "Huella incorrecta",
-                    "wrong_password": "Contraseña incorrecta",
-                    "low_battery": "Batería baja",
-                    "power_off": "Apagado"
-                }
-            },
-            "power_off": {
-                "name": "Apagado"
-            },
-            "battery": {
-                "name": "Batería"
-            },
-            "battery_charging": {
-                "name": "Carga de batería",
-                "state": {
-                    "charged": "Cargada",
-                    "charging": "Cargando",
-                    "not_charging": "No cargando"
-                }
-            },
-            "battery_state": {
-                "name": "Estado de la batería",
-                "state": {
-                    "high": "Alto",
-                    "low": "Bajo",
-                    "middle": "Medio",
-                    "normal": "Normal"
-                }
-            },
-            "carbon_dioxide": {
-                "name": "Dióxido de carbono"
-            },
-            "carbon_dioxide_alarm": {
-                "name": "Nivel de dióxido de carbono",
-                "state": {
-                    "alarm": "Alarma",
-                    "normal": "Normal"
-                }
-            },
-            "day_usage_after_reset": {
-                "name": "Uso diario después del reinicio"
-            },
-            "day_water_usage": {
-                "name": "Consumo de agua diario"
-            },
-            "flow_velocity": {
-                "name": "Caudal"
-            },
-            "lock_door_status": {
-                "name": "Estado de la puerta",
-                "state": {
-                    "door_status_unknown": "Desconocido",
-                    "door_status_open": "Abierto",
-                    "door_status_closed": "Cerrado"
-                }
-            },
-            "humidity": {
-                "name": "Humedad"
-            },
-            "low_battery": {
-                "name": "Batería baja"
-            },
-            "moisture": {
-                "name": "Humedad de suelo"
-            },
-            "work_state": {
-                "name": "Estado de funcionamiento"
-            },
-            "residual_electricity": {
-                "name": "Batería"
-            },
-            "signal_strength": {
-                "name": "Fuerza de la señal"
-            },
-            "temperature": {
-                "name": "Temperatura"
-            },
-            "time_left": {
-                "name": "Tiempo de riego restante"
-            },
-            "total_usage_after_reset": {
-                "name": "Uso total después del reinicio"
-            },
-            "use_time_z1": {
-                "name": "Último tiempo de riego - Zona 1"
-            },
-            "use_time_z2": {
-                "name": "Último tiempo de riego - Zona 2"
-            },
-            "use_time": {
-                "name": "Tiempo de uso acumulado"
-            },
-            "use_time_one": {
-                "name": "Último tiempo de riego"
-            },
-            "water_intake": {
-                "name": "Consumo de agua"
-            },
-            "water_once": {
-                "name": "Consumo de agua de la última sesión"
-            },
-            "water_use_data": {
-                "name": "Consumo de agua total"
-            },
-            "wrong_finger": {
-                "name": "Huella incorrecta"
-            },
-            "wrong_password": {
-                "name": "Contraseña incorrecta"
-            },
-            "unlock_fingerprint": {
-                "name": "Última huella utilizada"
-            },
-            "unlock_card": {
-                "name": "Última tarjeta utilizada"
-            },
-            "unlock_password": {
-                "name": "Última contraseña utilizada"
-            },
-            "unlock_key": {
-                "name": "Última llave utilizada"
-            },
-            "unlock_dynamic": {
-                "name": "Última contraseña dinámica utilizada"
-            },
-            "unlock_ble": {
-                "name": "Último Bluetooth utilizado"
-            },
-            "unlock_app": {
-                "name": "Última aplicación utilizada"
-            },
-            "unlock_voice": {
-                "name": "Última voz utilizada"
-            },
-            "unlock_temp_pwd": {
-                "name": "Última contraseña temporal utilizada"
-            }
-        },
-        "switch": {
-            "antifreeze": {
-                "name": "Anticongelante"
-            },
-            "carbon_dioxide_alarm_switch": {
-                "name": "Alarma habilitada"
-            },
-            "carbon_dioxide_severely_exceed_alarm": {
-                "name": "Alarma de exceso severo"
-            },
-            "child_lock": {
-                "name": "Cierre infantil"
-            },
-            "lock_motor_state": {
-                "name": "Estado del motor"
-            },
-            "low_battery_alarm": {
-                "name": "Alarma de batería baja"
-            },
-            "manual_control": {
-                "name": "Control manual"
-            },
-            "program": {
-                "name": "Programa"
-            },
-            "program_repeat_forever": {
-                "name": "Repetir indefinidamente"
-            },
-            "programming_mode": {
-                "name": "Modo programación"
-            },
-            "programming_switch": {
-                "name": "Interruptor de programación"
-            },
-            "reverse_positions": {
-                "name": "Invertir posiciones"
-            },
-            "switch": {
-                "name": "Interruptor"
-            },
-            "water_scale_proof": {
-                "name": "Antical"
-            },
-            "water_valve": {
-                "name": "Válvula de riego"
-            },
-            "water_valve_z1": {
-                "name": "Válvula de riego - Zona 1"
-            },
-            "water_valve_z2": {
-                "name": "Válvula de riego - Zona 2"
-            },
-            "weather_switch": {
-                "name": "Interruptor de clima"
-            },
-            "window_check": {
-                "name": "Detección de ventanas"
-            }
-        },
-        "text": {
-            "program": {
-                "name": "Programa: posición[/tiempo];..."
-            }
-        },
-        "vacuum": {
-            "vacuum": {
-                "name": "Limpiacristales"
-            }
-        }
+    "error": {
+      "device_not_registered": "El dispositivo no está registrado en la nube de Tuya",
+      "invalid_auth": "Autenticación inválida",
+      "login_error": "Error de inicio de sesión ({code}): {msg}"
     },
-    "options": {
-        "error": {
-            "device_not_registered": "El dispositivo no está registrado en la nube de Tuya",
-            "invalid_auth": "Autenticación inválida",
-            "login_error": "Error de inicio de sesión ({code}): {msg}"
+    "flow_title": "{name}",
+    "step": {
+      "device": {
+        "data": {
+          "address": "Dispositivo Tuya BLE"
         },
-        "step": {
-            "login": {
-                "data": {
-                    "access_id": "ID de acceso de Tuya IoT",
-                    "access_secret": "Clave secreta de Tuya IoT",
-                    "country_code": "País",
-                    "password": "Contraseña",
-                    "username": "Cuenta"
-                },
-                "description": "Consulte la documentación de la integración de Tuya para obtener las credenciales de la nube {url}\n\nIntroduzca sus credenciales de Tuya."
-            }
-        }
+        "description": "Seleccione el dispositivo Tuya BLE para configurar. El dispositivo debe estar registrado en la nube mediante la aplicación móvil. Se recomienda desvincular el dispositivo de cualquier puerta de enlace Bluetooth de Tuya."
+      },
+      "login": {
+        "data": {
+          "access_id": "ID de acceso de Tuya IoT",
+          "access_secret": "Clave secreta de Tuya IoT",
+          "country_code": "País",
+          "password": "Contraseña",
+          "username": "Cuenta"
+        },
+        "description": "Tuya BLE requiere obtener la clave de cifrado de la nube de Tuya. Casi todos los dispositivos solo necesitan acceder a la nube una vez durante la configuración.\n\nConsulte la documentación de la integración de Tuya para obtener las credenciales de la nube {url}\n\nIntroduzca sus credenciales de Tuya."
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "fault": {
+        "name": "Fallo"
+      },
+      "lack_water": {
+        "name": "Falta de agua"
+      },
+      "low_battery": {
+        "name": "Batería"
+      },
+      "lock_motor_state": {
+        "name": "Estado del motor"
+      },
+      "low_temp": {
+        "name": "Baja temperatura"
+      },
+      "motor_fault": {
+        "name": "Fallo del motor"
+      },
+      "sensor_fault": {
+        "name": "Fallo del sensor"
+      }
+    },
+    "button": {
+      "push": {
+        "name": "Pulsar"
+      },
+      "ble_unlock_check": {
+        "name": "Desbloquear"
+      },
+      "bluetooth_unlock": {
+        "name": "Desbloquear"
+      }
+    },
+    "event": {
+      "event": {
+        "name": "Evento"
+      }
+    },
+    "number": {
+      "ble_unlock_check": {
+        "name": "Desbloquear"
+      },
+      "brightness": {
+        "name": "Brillo"
+      },
+      "carbon_dioxide_alarm_level": {
+        "name": "Nivel de alarma"
+      },
+      "countdown": {
+        "name": "Duración del riego"
+      },
+      "countdown_duration": {
+        "name": "Duración del riego"
+      },
+      "countdown_duration_z1": {
+        "name": "Duración del riego - Zona 1"
+      },
+      "countdown_duration_z2": {
+        "name": "Duración del riego - Zona 2"
+      },
+      "down_position": {
+        "name": "Posición abajo"
+      },
+      "hold_time": {
+        "name": "Tiempo de espera"
+      },
+      "humidity_calibration": {
+        "name": "Calibración de humedad"
+      },
+      "program_idle_position": {
+        "name": "Posición de reposo"
+      },
+      "program_repeats_count": {
+        "name": "Número de repeticiones"
+      },
+      "recommended_water_intake": {
+        "name": "Consumo de agua recomendado"
+      },
+      "reporting_period": {
+        "name": "Período de reporte"
+      },
+      "temperature_calibration": {
+        "name": "Calibración de temperatura"
+      },
+      "up_position": {
+        "name": "Posición arriba"
+      }
+    },
+    "select": {
+      "beep_volume": {
+        "name": "Volumen de la cerradura"
+      },
+      "language": {
+        "name": "Idioma de la cerradura"
+      },
+      "fingerbot_mode": {
+        "name": "Modo",
+        "state": {
+          "program": "Programa",
+          "push": "Pulsar",
+          "switch": "Interruptor"
+        }
+      },
+      "weather_delay": {
+        "name": "Retraso meteorológico"
+      },
+      "smart_weather": {
+        "name": "Clima inteligente"
+      },
+      "reminder_mode": {
+        "name": "Modo de recordatorio",
+        "state": {
+          "interval_reminder": "Intervalo",
+          "schedule_reminder": "Programación"
+        }
+      },
+      "temperature_unit": {
+        "name": "Unidad de temperatura"
+      }
+    },
+    "sensor": {
+      "alarm_lock": {
+        "name": "Alarma",
+        "state": {
+          "wrong_finger": "Huella incorrecta",
+          "wrong_password": "Contraseña incorrecta",
+          "low_battery": "Batería baja",
+          "power_off": "Apagado"
+        }
+      },
+      "power_off": {
+        "name": "Apagado"
+      },
+      "battery": {
+        "name": "Batería"
+      },
+      "battery_charging": {
+        "name": "Carga de batería",
+        "state": {
+          "charged": "Cargada",
+          "charging": "Cargando",
+          "not_charging": "No cargando"
+        }
+      },
+      "battery_state": {
+        "name": "Estado de la batería",
+        "state": {
+          "high": "Alto",
+          "low": "Bajo",
+          "middle": "Medio",
+          "normal": "Normal"
+        }
+      },
+      "carbon_dioxide": {
+        "name": "Dióxido de carbono"
+      },
+      "carbon_dioxide_alarm": {
+        "name": "Nivel de dióxido de carbono",
+        "state": {
+          "alarm": "Alarma",
+          "normal": "Normal"
+        }
+      },
+      "day_usage_after_reset": {
+        "name": "Uso diario después del reinicio"
+      },
+      "day_water_usage": {
+        "name": "Consumo de agua diario"
+      },
+      "flow_velocity": {
+        "name": "Caudal"
+      },
+      "lock_door_status": {
+        "name": "Estado de la puerta",
+        "state": {
+          "door_status_unknown": "Desconocido",
+          "door_status_open": "Abierto",
+          "door_status_closed": "Cerrado"
+        }
+      },
+      "humidity": {
+        "name": "Humedad"
+      },
+      "low_battery": {
+        "name": "Batería baja"
+      },
+      "moisture": {
+        "name": "Humedad de suelo"
+      },
+      "work_state": {
+        "name": "Estado de funcionamiento"
+      },
+      "residual_electricity": {
+        "name": "Batería"
+      },
+      "signal_strength": {
+        "name": "Fuerza de la señal"
+      },
+      "temperature": {
+        "name": "Temperatura"
+      },
+      "time_left": {
+        "name": "Tiempo de riego restante"
+      },
+      "total_usage_after_reset": {
+        "name": "Uso total después del reinicio"
+      },
+      "use_time_z1": {
+        "name": "Último tiempo de riego - Zona 1"
+      },
+      "use_time_z2": {
+        "name": "Último tiempo de riego - Zona 2"
+      },
+      "use_time": {
+        "name": "Tiempo de uso acumulado"
+      },
+      "use_time_one": {
+        "name": "Último tiempo de riego"
+      },
+      "water_intake": {
+        "name": "Consumo de agua"
+      },
+      "water_once": {
+        "name": "Consumo de agua de la última sesión"
+      },
+      "water_use_data": {
+        "name": "Consumo de agua total"
+      },
+      "wrong_finger": {
+        "name": "Huella incorrecta"
+      },
+      "wrong_password": {
+        "name": "Contraseña incorrecta"
+      },
+      "unlock_fingerprint": {
+        "name": "Última huella utilizada"
+      },
+      "unlock_card": {
+        "name": "Última tarjeta utilizada"
+      },
+      "unlock_password": {
+        "name": "Última contraseña utilizada"
+      },
+      "unlock_key": {
+        "name": "Última llave utilizada"
+      },
+      "unlock_dynamic": {
+        "name": "Última contraseña dinámica utilizada"
+      },
+      "unlock_ble": {
+        "name": "Último Bluetooth utilizado"
+      },
+      "unlock_app": {
+        "name": "Última aplicación utilizada"
+      },
+      "unlock_voice": {
+        "name": "Última voz utilizada"
+      },
+      "unlock_temp_pwd": {
+        "name": "Última contraseña temporal utilizada"
+      },
+      "weather_delay_remaining": {
+        "name": "Retraso meteorológico restante"
+      },
+      "weather": {
+        "name": "Tiempo",
+        "state": {
+          "sunny": "Soleado",
+          "cloudy": "Nublado",
+          "rainy": "Lluvioso",
+          "snowy": "Nevoso",
+          "null": "No disponible"
+        }
+      },
+      "spray_time_z1": {
+        "name": "Duración de pulverización - Zona 1"
+      },
+      "spray_time_z2": {
+        "name": "Duración de pulverización - Zona 2"
+      },
+      "work_state_z1": {
+        "name": "Estado de trabajo - Zona 1",
+        "state": {
+          "idle": "Inactivo",
+          "manual": "Manual",
+          "spray": "Pulverización",
+          "timing": "Programado"
+        }
+      },
+      "work_state_z2": {
+        "name": "Estado de trabajo - Zona 2",
+        "state": {
+          "idle": "Inactivo",
+          "manual": "Manual",
+          "spray": "Pulverización",
+          "timing": "Programado"
+        }
+      }
+    },
+    "switch": {
+      "antifreeze": {
+        "name": "Anticongelante"
+      },
+      "carbon_dioxide_alarm_switch": {
+        "name": "Alarma habilitada"
+      },
+      "carbon_dioxide_severely_exceed_alarm": {
+        "name": "Alarma de exceso severo"
+      },
+      "child_lock": {
+        "name": "Cierre infantil"
+      },
+      "lock_motor_state": {
+        "name": "Estado del motor"
+      },
+      "low_battery_alarm": {
+        "name": "Alarma de batería baja"
+      },
+      "manual_control": {
+        "name": "Control manual"
+      },
+      "program": {
+        "name": "Programa"
+      },
+      "program_repeat_forever": {
+        "name": "Repetir indefinidamente"
+      },
+      "programming_mode": {
+        "name": "Modo programación"
+      },
+      "programming_switch": {
+        "name": "Interruptor de programación"
+      },
+      "reverse_positions": {
+        "name": "Invertir posiciones"
+      },
+      "switch": {
+        "name": "Interruptor"
+      },
+      "water_scale_proof": {
+        "name": "Antical"
+      },
+      "water_valve": {
+        "name": "Válvula de riego"
+      },
+      "water_valve_z1": {
+        "name": "Válvula de riego - Zona 1"
+      },
+      "water_valve_z2": {
+        "name": "Válvula de riego - Zona 2"
+      },
+      "weather_switch": {
+        "name": "Interruptor de clima"
+      },
+      "window_check": {
+        "name": "Detección de ventanas"
+      }
+    },
+    "text": {
+      "program": {
+        "name": "Programa: posición[/tiempo];..."
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "Limpiacristales"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_registered": "El dispositivo no está registrado en la nube de Tuya",
+      "invalid_auth": "Autenticación inválida",
+      "login_error": "Error de inicio de sesión ({code}): {msg}"
+    },
+    "step": {
+      "login": {
+        "data": {
+          "access_id": "ID de acceso de Tuya IoT",
+          "access_secret": "Clave secreta de Tuya IoT",
+          "country_code": "País",
+          "password": "Contraseña",
+          "username": "Cuenta"
+        },
+        "description": "Consulte la documentación de la integración de Tuya para obtener las credenciales de la nube {url}\n\nIntroduzca sus credenciales de Tuya."
+      }
+    }
+  }
 }

--- a/custom_components/tuya_ble/translations/fr.json
+++ b/custom_components/tuya_ble/translations/fr.json
@@ -1,384 +1,421 @@
 {
-    "config": {
-        "abort": {
-            "no_unconfigured_devices": "Aucun appareil non configuré trouvé."
-        },
-        "error": {
-            "device_not_registered": "L'appareil n'est pas enregistré dans le cloud Tuya",
-            "invalid_auth": "Authentification invalide",
-            "login_error": "Erreur de connexion ({code}) : {msg}"
-        },
-        "flow_title": "{name}",
-        "step": {
-            "device": {
-                "data": {
-                    "address": "Appareil Tuya BLE"
-                },
-                "description": "Sélectionnez l'appareil Tuya BLE à configurer. L'appareil doit être enregistré dans le cloud à l'aide de l'application mobile. Il est préférable de dissocier l'appareil de la passerelle Bluetooth Tuya, le cas échéant."
-            },
-            "login": {
-                "data": {
-                    "access_id": "ID d'accès Tuya IoT",
-                    "access_secret": "Clé secrète d'accès Tuya IoT",
-                    "country_code": "Pays",
-                    "password": "Mot de passe",
-                    "username": "Compte"
-                },
-                "description": "Tuya BLE nécessite d'obtenir la clé de chiffrement auprès du cloud Tuya. Presque tous les appareils n'ont besoin d'accéder au cloud qu'une seule fois lors de la configuration.\n\nReportez-vous à la documentation de l'intégration Tuya pour récupérer les identifiants cloud {url}\n\nEntrez vos identifiants Tuya."
-            }
-        }
+  "config": {
+    "abort": {
+      "no_unconfigured_devices": "Aucun appareil non configuré trouvé."
     },
-    "entity": {
-        "binary_sensor": {
-            "fault": {
-                "name": "Défaut"
-            },
-            "lack_water": {
-                "name": "Manque d'eau"
-            },
-            "low_battery": {
-                "name": "Batterie"
-            },
-            "lock_motor_state": {
-                "name": "État du moteur"
-            },
-            "low_temp": {
-                "name": "Basse température"
-            },
-            "motor_fault": {
-                "name": "Défaut moteur"
-            },
-            "sensor_fault": {
-                "name": "Défaut capteur"
-            }
-        },
-        "button": {
-            "push": {
-                "name": "Pousser"
-            },
-            "ble_unlock_check": {
-                "name": "Déverrouiller"
-            },
-            "bluetooth_unlock": {
-                "name": "Déverrouiller"
-            }
-        },
-        "event": {
-            "event": {
-                "name": "Événement"
-            }
-        },
-        "number": {
-            "ble_unlock_check": {
-                "name": "Déverrouiller"
-            },
-            "brightness": {
-                "name": "Luminosité"
-            },
-            "carbon_dioxide_alarm_level": {
-                "name": "Niveau d'alarme"
-            },
-            "countdown": {
-                "name": "Durée d'arrosage"
-            },
-            "countdown_duration": {
-                "name": "Durée d'arrosage"
-            },
-            "countdown_duration_z1": {
-                "name": "Durée d'arrosage - Zone 1"
-            },
-            "countdown_duration_z2": {
-                "name": "Durée d'arrosage - Zone 2"
-            },
-            "down_position": {
-                "name": "Position basse"
-            },
-            "hold_time": {
-                "name": "Temps de maintien"
-            },
-            "humidity_calibration": {
-                "name": "Calibrage de l'humidité"
-            },
-            "program_idle_position": {
-                "name": "Position de repos"
-            },
-            "program_repeats_count": {
-                "name": "Nombre de répétitions"
-            },
-            "recommended_water_intake": {
-                "name": "Consommation d'eau recommandée"
-            },
-            "reporting_period": {
-                "name": "Période de rapport"
-            },
-            "temperature_calibration": {
-                "name": "Calibrage de la température"
-            },
-            "up_position": {
-                "name": "Position haute"
-            }
-        },
-        "select": {
-            "beep_volume": {
-                "name": "Volume de la serrure"
-            },
-            "language": {
-                "name": "Langue de la serrure"
-            },
-            "fingerbot_mode": {
-                "name": "Mode",
-                "state": {
-                    "program": "Programme",
-                    "push": "Pousser",
-                    "switch": "Interrupteur"
-                }
-            },
-            "weather_delay": {
-                "name": "Délai météo"
-            },
-            "smart_weather": {
-                "name": "Météo intelligente"
-            },
-            "reminder_mode": {
-                "name": "Mode de rappel",
-                "state": {
-                    "interval_reminder": "Intervalle",
-                    "schedule_reminder": "Planification"
-                }
-            },
-            "temperature_unit": {
-                "name": "Unité de température"
-            }
-        },
-        "sensor": {
-            "alarm_lock": {
-                "name": "Alarme",
-                "state": {
-                    "wrong_finger": "Empreinte incorrecte",
-                    "wrong_password": "Mot de passe incorrect",
-                    "low_battery": "Batterie faible",
-                    "power_off": "Éteint"
-                }
-            },
-            "power_off": {
-                "name": "Éteint"
-            },
-            "battery": {
-                "name": "Batterie"
-            },
-            "battery_charging": {
-                "name": "Charge de la batterie",
-                "state": {
-                    "charged": "Chargée",
-                    "charging": "En charge",
-                    "not_charging": "Pas en charge"
-                }
-            },
-            "battery_state": {
-                "name": "État de la batterie",
-                "state": {
-                    "high": "Haut",
-                    "low": "Bas",
-                    "middle": "Moyen",
-                    "normal": "Normal"
-                }
-            },
-            "carbon_dioxide": {
-                "name": "Dioxyde de carbone"
-            },
-            "carbon_dioxide_alarm": {
-                "name": "Niveau de dioxyde de carbone",
-                "state": {
-                    "alarm": "Alarme",
-                    "normal": "Normal"
-                }
-            },
-            "day_usage_after_reset": {
-                "name": "Consommation quotidienne après réinitialisation"
-            },
-            "day_water_usage": {
-                "name": "Consommation d'eau quotidienne"
-            },
-            "flow_velocity": {
-                "name": "Débit"
-            },
-            "lock_door_status": {
-                "name": "État de la porte",
-                "state": {
-                    "door_status_unknown": "Inconnu",
-                    "door_status_open": "Ouvert",
-                    "door_status_closed": "Fermé"
-                }
-            },
-            "humidity": {
-                "name": "Humidité"
-            },
-            "low_battery": {
-                "name": "Batterie faible"
-            },
-            "moisture": {
-                "name": "Humidité du sol"
-            },
-            "work_state": {
-                "name": "État de fonctionnement"
-            },
-            "residual_electricity": {
-                "name": "Batterie"
-            },
-            "signal_strength": {
-                "name": "Force du signal"
-            },
-            "temperature": {
-                "name": "Température"
-            },
-            "time_left": {
-                "name": "Temps d'arrosage restant"
-            },
-            "total_usage_after_reset": {
-                "name": "Consommation totale après réinitialisation"
-            },
-            "use_time_z1": {
-                "name": "Dernier temps d'arrosage - Zone 1"
-            },
-            "use_time_z2": {
-                "name": "Dernier temps d'arrosage - Zone 2"
-            },
-            "use_time": {
-                "name": "Temps d'utilisation accumulé"
-            },
-            "use_time_one": {
-                "name": "Dernier temps d'arrosage"
-            },
-            "water_intake": {
-                "name": "Consommation d'eau"
-            },
-            "water_once": {
-                "name": "Consommation d'eau de la dernière session"
-            },
-            "water_use_data": {
-                "name": "Consommation d'eau totale"
-            },
-            "wrong_finger": {
-                "name": "Empreinte incorrecte"
-            },
-            "wrong_password": {
-                "name": "Mot de passe incorrect"
-            },
-            "unlock_fingerprint": {
-                "name": "Dernière empreinte utilisée"
-            },
-            "unlock_card": {
-                "name": "Dernière carte utilisée"
-            },
-            "unlock_password": {
-                "name": "Dernier mot de passe utilisé"
-            },
-            "unlock_key": {
-                "name": "Dernière clé utilisée"
-            },
-            "unlock_dynamic": {
-                "name": "Dernier mot de passe dynamique utilisé"
-            },
-            "unlock_ble": {
-                "name": "Dernier Bluetooth utilisé"
-            },
-            "unlock_app": {
-                "name": "Dernière application utilisée"
-            },
-            "unlock_voice": {
-                "name": "Dernière voix utilisée"
-            },
-            "unlock_temp_pwd": {
-                "name": "Dernier mot de passe temporaire utilisé"
-            }
-        },
-        "switch": {
-            "antifreeze": {
-                "name": "Antigel"
-            },
-            "carbon_dioxide_alarm_switch": {
-                "name": "Alarme activée"
-            },
-            "carbon_dioxide_severely_exceed_alarm": {
-                "name": "Alarme de dépassement sévère"
-            },
-            "child_lock": {
-                "name": "Sécurité enfant"
-            },
-            "lock_motor_state": {
-                "name": "État du moteur"
-            },
-            "low_battery_alarm": {
-                "name": "Alarme de batterie faible"
-            },
-            "manual_control": {
-                "name": "Contrôle manuel"
-            },
-            "program": {
-                "name": "Programme"
-            },
-            "program_repeat_forever": {
-                "name": "Répéter indéfiniment"
-            },
-            "programming_mode": {
-                "name": "Mode programmation"
-            },
-            "programming_switch": {
-                "name": "Interrupteur de programmation"
-            },
-            "reverse_positions": {
-                "name": "Inverser les positions"
-            },
-            "switch": {
-                "name": "Interrupteur"
-            },
-            "water_scale_proof": {
-                "name": "Anti-tartre"
-            },
-            "water_valve": {
-                "name": "Vanne d'arrosage"
-            },
-            "water_valve_z1": {
-                "name": "Vanne d'arrosage - Zone 1"
-            },
-            "water_valve_z2": {
-                "name": "Vanne d'arrosage - Zone 2"
-            },
-            "weather_switch": {
-                "name": "Interrupteur météo"
-            },
-            "window_check": {
-                "name": "Détection de fenêtre"
-            }
-        },
-        "text": {
-            "program": {
-                "name": "Programme : position[/temps] ; ..."
-            }
-        },
-        "vacuum": {
-            "vacuum": {
-                "name": "Nettoyeur de vitres"
-            }
-        }
+    "error": {
+      "device_not_registered": "L'appareil n'est pas enregistré dans le cloud Tuya",
+      "invalid_auth": "Authentification invalide",
+      "login_error": "Erreur de connexion ({code}) : {msg}"
     },
-    "options": {
-        "error": {
-            "device_not_registered": "L'appareil n'est pas enregistré dans le cloud Tuya",
-            "invalid_auth": "Authentification invalide",
-            "login_error": "Erreur de connexion ({code}) : {msg}"
+    "flow_title": "{name}",
+    "step": {
+      "device": {
+        "data": {
+          "address": "Appareil Tuya BLE"
         },
-        "step": {
-            "login": {
-                "data": {
-                    "access_id": "ID d'accès Tuya IoT",
-                    "access_secret": "Clé secrète d'accès Tuya IoT",
-                    "country_code": "Pays",
-                    "password": "Mot de passe",
-                    "username": "Compte"
-                },
-                "description": "Reportez-vous à la documentation de l'intégration Tuya pour récupérer les identifiants cloud {url}\n\nEntrez vos identifiants Tuya."
-            }
-        }
+        "description": "Sélectionnez l'appareil Tuya BLE à configurer. L'appareil doit être enregistré dans le cloud à l'aide de l'application mobile. Il est préférable de dissocier l'appareil de la passerelle Bluetooth Tuya, le cas échéant."
+      },
+      "login": {
+        "data": {
+          "access_id": "ID d'accès Tuya IoT",
+          "access_secret": "Clé secrète d'accès Tuya IoT",
+          "country_code": "Pays",
+          "password": "Mot de passe",
+          "username": "Compte"
+        },
+        "description": "Tuya BLE nécessite d'obtenir la clé de chiffrement auprès du cloud Tuya. Presque tous les appareils n'ont besoin d'accéder au cloud qu'une seule fois lors de la configuration.\n\nReportez-vous à la documentation de l'intégration Tuya pour récupérer les identifiants cloud {url}\n\nEntrez vos identifiants Tuya."
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "fault": {
+        "name": "Défaut"
+      },
+      "lack_water": {
+        "name": "Manque d'eau"
+      },
+      "low_battery": {
+        "name": "Batterie"
+      },
+      "lock_motor_state": {
+        "name": "État du moteur"
+      },
+      "low_temp": {
+        "name": "Basse température"
+      },
+      "motor_fault": {
+        "name": "Défaut moteur"
+      },
+      "sensor_fault": {
+        "name": "Défaut capteur"
+      }
+    },
+    "button": {
+      "push": {
+        "name": "Pousser"
+      },
+      "ble_unlock_check": {
+        "name": "Déverrouiller"
+      },
+      "bluetooth_unlock": {
+        "name": "Déverrouiller"
+      }
+    },
+    "event": {
+      "event": {
+        "name": "Événement"
+      }
+    },
+    "number": {
+      "ble_unlock_check": {
+        "name": "Déverrouiller"
+      },
+      "brightness": {
+        "name": "Luminosité"
+      },
+      "carbon_dioxide_alarm_level": {
+        "name": "Niveau d'alarme"
+      },
+      "countdown": {
+        "name": "Durée d'arrosage"
+      },
+      "countdown_duration": {
+        "name": "Durée d'arrosage"
+      },
+      "countdown_duration_z1": {
+        "name": "Durée d'arrosage - Zone 1"
+      },
+      "countdown_duration_z2": {
+        "name": "Durée d'arrosage - Zone 2"
+      },
+      "down_position": {
+        "name": "Position basse"
+      },
+      "hold_time": {
+        "name": "Temps de maintien"
+      },
+      "humidity_calibration": {
+        "name": "Calibrage de l'humidité"
+      },
+      "program_idle_position": {
+        "name": "Position de repos"
+      },
+      "program_repeats_count": {
+        "name": "Nombre de répétitions"
+      },
+      "recommended_water_intake": {
+        "name": "Consommation d'eau recommandée"
+      },
+      "reporting_period": {
+        "name": "Période de rapport"
+      },
+      "temperature_calibration": {
+        "name": "Calibrage de la température"
+      },
+      "up_position": {
+        "name": "Position haute"
+      }
+    },
+    "select": {
+      "beep_volume": {
+        "name": "Volume de la serrure"
+      },
+      "language": {
+        "name": "Langue de la serrure"
+      },
+      "fingerbot_mode": {
+        "name": "Mode",
+        "state": {
+          "program": "Programme",
+          "push": "Pousser",
+          "switch": "Interrupteur"
+        }
+      },
+      "weather_delay": {
+        "name": "Délai météo"
+      },
+      "smart_weather": {
+        "name": "Météo intelligente"
+      },
+      "reminder_mode": {
+        "name": "Mode de rappel",
+        "state": {
+          "interval_reminder": "Intervalle",
+          "schedule_reminder": "Planification"
+        }
+      },
+      "temperature_unit": {
+        "name": "Unité de température"
+      }
+    },
+    "sensor": {
+      "alarm_lock": {
+        "name": "Alarme",
+        "state": {
+          "wrong_finger": "Empreinte incorrecte",
+          "wrong_password": "Mot de passe incorrect",
+          "low_battery": "Batterie faible",
+          "power_off": "Éteint"
+        }
+      },
+      "power_off": {
+        "name": "Éteint"
+      },
+      "battery": {
+        "name": "Batterie"
+      },
+      "battery_charging": {
+        "name": "Charge de la batterie",
+        "state": {
+          "charged": "Chargée",
+          "charging": "En charge",
+          "not_charging": "Pas en charge"
+        }
+      },
+      "battery_state": {
+        "name": "État de la batterie",
+        "state": {
+          "high": "Haut",
+          "low": "Bas",
+          "middle": "Moyen",
+          "normal": "Normal"
+        }
+      },
+      "carbon_dioxide": {
+        "name": "Dioxyde de carbone"
+      },
+      "carbon_dioxide_alarm": {
+        "name": "Niveau de dioxyde de carbone",
+        "state": {
+          "alarm": "Alarme",
+          "normal": "Normal"
+        }
+      },
+      "day_usage_after_reset": {
+        "name": "Consommation quotidienne après réinitialisation"
+      },
+      "day_water_usage": {
+        "name": "Consommation d'eau quotidienne"
+      },
+      "flow_velocity": {
+        "name": "Débit"
+      },
+      "lock_door_status": {
+        "name": "État de la porte",
+        "state": {
+          "door_status_unknown": "Inconnu",
+          "door_status_open": "Ouvert",
+          "door_status_closed": "Fermé"
+        }
+      },
+      "humidity": {
+        "name": "Humidité"
+      },
+      "low_battery": {
+        "name": "Batterie faible"
+      },
+      "moisture": {
+        "name": "Humidité du sol"
+      },
+      "work_state": {
+        "name": "État de fonctionnement"
+      },
+      "residual_electricity": {
+        "name": "Batterie"
+      },
+      "signal_strength": {
+        "name": "Force du signal"
+      },
+      "temperature": {
+        "name": "Température"
+      },
+      "time_left": {
+        "name": "Temps d'arrosage restant"
+      },
+      "total_usage_after_reset": {
+        "name": "Consommation totale après réinitialisation"
+      },
+      "use_time_z1": {
+        "name": "Dernier temps d'arrosage - Zone 1"
+      },
+      "use_time_z2": {
+        "name": "Dernier temps d'arrosage - Zone 2"
+      },
+      "use_time": {
+        "name": "Temps d'utilisation accumulé"
+      },
+      "use_time_one": {
+        "name": "Dernier temps d'arrosage"
+      },
+      "water_intake": {
+        "name": "Consommation d'eau"
+      },
+      "water_once": {
+        "name": "Consommation d'eau de la dernière session"
+      },
+      "water_use_data": {
+        "name": "Consommation d'eau totale"
+      },
+      "wrong_finger": {
+        "name": "Empreinte incorrecte"
+      },
+      "wrong_password": {
+        "name": "Mot de passe incorrect"
+      },
+      "unlock_fingerprint": {
+        "name": "Dernière empreinte utilisée"
+      },
+      "unlock_card": {
+        "name": "Dernière carte utilisée"
+      },
+      "unlock_password": {
+        "name": "Dernier mot de passe utilisé"
+      },
+      "unlock_key": {
+        "name": "Dernière clé utilisée"
+      },
+      "unlock_dynamic": {
+        "name": "Dernier mot de passe dynamique utilisé"
+      },
+      "unlock_ble": {
+        "name": "Dernier Bluetooth utilisé"
+      },
+      "unlock_app": {
+        "name": "Dernière application utilisée"
+      },
+      "unlock_voice": {
+        "name": "Dernière voix utilisée"
+      },
+      "unlock_temp_pwd": {
+        "name": "Dernier mot de passe temporaire utilisé"
+      },
+      "weather_delay_remaining": {
+        "name": "Délai météo restant"
+      },
+      "weather": {
+        "name": "Météo",
+        "state": {
+          "sunny": "Ensoleillé",
+          "cloudy": "Nuageux",
+          "rainy": "Pluvieux",
+          "snowy": "Neigeux",
+          "null": "Indisponible"
+        }
+      },
+      "spray_time_z1": {
+        "name": "Durée de pulvérisation - Zone 1"
+      },
+      "spray_time_z2": {
+        "name": "Durée de pulvérisation - Zone 2"
+      },
+      "work_state_z1": {
+        "name": "État de fonctionnement - Zone 1",
+        "state": {
+          "idle": "Inactif",
+          "manual": "Manuel",
+          "spray": "Pulvérisation",
+          "timing": "Planifié"
+        }
+      },
+      "work_state_z2": {
+        "name": "État de fonctionnement - Zone 2",
+        "state": {
+          "idle": "Inactif",
+          "manual": "Manuel",
+          "spray": "Pulvérisation",
+          "timing": "Planifié"
+        }
+      }
+    },
+    "switch": {
+      "antifreeze": {
+        "name": "Antigel"
+      },
+      "carbon_dioxide_alarm_switch": {
+        "name": "Alarme activée"
+      },
+      "carbon_dioxide_severely_exceed_alarm": {
+        "name": "Alarme de dépassement sévère"
+      },
+      "child_lock": {
+        "name": "Sécurité enfant"
+      },
+      "lock_motor_state": {
+        "name": "État du moteur"
+      },
+      "low_battery_alarm": {
+        "name": "Alarme de batterie faible"
+      },
+      "manual_control": {
+        "name": "Contrôle manuel"
+      },
+      "program": {
+        "name": "Programme"
+      },
+      "program_repeat_forever": {
+        "name": "Répéter indéfiniment"
+      },
+      "programming_mode": {
+        "name": "Mode programmation"
+      },
+      "programming_switch": {
+        "name": "Interrupteur de programmation"
+      },
+      "reverse_positions": {
+        "name": "Inverser les positions"
+      },
+      "switch": {
+        "name": "Interrupteur"
+      },
+      "water_scale_proof": {
+        "name": "Anti-tartre"
+      },
+      "water_valve": {
+        "name": "Vanne d'arrosage"
+      },
+      "water_valve_z1": {
+        "name": "Vanne d'arrosage - Zone 1"
+      },
+      "water_valve_z2": {
+        "name": "Vanne d'arrosage - Zone 2"
+      },
+      "weather_switch": {
+        "name": "Interrupteur météo"
+      },
+      "window_check": {
+        "name": "Détection de fenêtre"
+      }
+    },
+    "text": {
+      "program": {
+        "name": "Programme : position[/temps] ; ..."
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "Nettoyeur de vitres"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_registered": "L'appareil n'est pas enregistré dans le cloud Tuya",
+      "invalid_auth": "Authentification invalide",
+      "login_error": "Erreur de connexion ({code}) : {msg}"
+    },
+    "step": {
+      "login": {
+        "data": {
+          "access_id": "ID d'accès Tuya IoT",
+          "access_secret": "Clé secrète d'accès Tuya IoT",
+          "country_code": "Pays",
+          "password": "Mot de passe",
+          "username": "Compte"
+        },
+        "description": "Reportez-vous à la documentation de l'intégration Tuya pour récupérer les identifiants cloud {url}\n\nEntrez vos identifiants Tuya."
+      }
+    }
+  }
 }

--- a/custom_components/tuya_ble/translations/it.json
+++ b/custom_components/tuya_ble/translations/it.json
@@ -1,384 +1,421 @@
 {
-    "config": {
-        "abort": {
-            "no_unconfigured_devices": "Nessun dispositivo non configurato trovato."
-        },
-        "error": {
-            "device_not_registered": "Il dispositivo non è registrato nel cloud Tuya",
-            "invalid_auth": "Autenticazione non valida",
-            "login_error": "Errore di accesso ({code}): {msg}"
-        },
-        "flow_title": "{name}",
-        "step": {
-            "device": {
-                "data": {
-                    "address": "Dispositivo Tuya BLE"
-                },
-                "description": "Seleziona il dispositivo Tuya BLE da configurare. Il dispositivo deve essere registrato nel cloud tramite l'applicazione mobile. Si consiglia di disassociare il dispositivo dal gateway Bluetooth Tuya, se presente."
-            },
-            "login": {
-                "data": {
-                    "access_id": "Tuya IoT Access ID",
-                    "access_secret": "Tuya IoT Access Secret",
-                    "country_code": "Paese",
-                    "password": "Password",
-                    "username": "Account"
-                },
-                "description": "Tuya BLE richiede di ottenere la chiave di crittografia dal cloud Tuya. Quasi tutti i dispositivi devono accedere al cloud solo una volta durante la configurazione.\n\nFai riferimento alla documentazione dell'integrazione Tuya per recuperare le credenziali cloud {url}\n\nInserisci le tue credenziali Tuya."
-            }
-        }
+  "config": {
+    "abort": {
+      "no_unconfigured_devices": "Nessun dispositivo non configurato trovato."
     },
-    "entity": {
-        "binary_sensor": {
-            "fault": {
-                "name": "Guasto"
-            },
-            "lack_water": {
-                "name": "Mancanza d'acqua"
-            },
-            "low_battery": {
-                "name": "Batteria"
-            },
-            "lock_motor_state": {
-                "name": "Stato motore"
-            },
-            "low_temp": {
-                "name": "Bassa temperatura"
-            },
-            "motor_fault": {
-                "name": "Guasto motore"
-            },
-            "sensor_fault": {
-                "name": "Guasto sensore"
-            }
-        },
-        "button": {
-            "push": {
-                "name": "Premi"
-            },
-            "ble_unlock_check": {
-                "name": "Sblocca"
-            },
-            "bluetooth_unlock": {
-                "name": "Sblocca"
-            }
-        },
-        "event": {
-            "event": {
-                "name": "Evento"
-            }
-        },
-        "number": {
-            "ble_unlock_check": {
-                "name": "Sblocca"
-            },
-            "brightness": {
-                "name": "Luminosità"
-            },
-            "carbon_dioxide_alarm_level": {
-                "name": "Livello d'allarme"
-            },
-            "countdown": {
-                "name": "Durata irrigazione"
-            },
-            "countdown_duration": {
-                "name": "Durata irrigazione"
-            },
-            "countdown_duration_z1": {
-                "name": "Durata irrigazione - Zona 1"
-            },
-            "countdown_duration_z2": {
-                "name": "Durata irrigazione - Zona 2"
-            },
-            "down_position": {
-                "name": "Posizione giù"
-            },
-            "hold_time": {
-                "name": "Tempo di mantenimento"
-            },
-            "humidity_calibration": {
-                "name": "Calibrazione dell'umidità"
-            },
-            "program_idle_position": {
-                "name": "Posizione di riposo"
-            },
-            "program_repeats_count": {
-                "name": "Numero di ripetizioni"
-            },
-            "recommended_water_intake": {
-                "name": "Consumo d'acqua raccomandato"
-            },
-            "reporting_period": {
-                "name": "Periodo di segnalazione"
-            },
-            "temperature_calibration": {
-                "name": "Calibrazione della temperatura"
-            },
-            "up_position": {
-                "name": "Posizione su"
-            }
-        },
-        "select": {
-            "beep_volume": {
-                "name": "Volume serratura"
-            },
-            "language": {
-                "name": "Lingua serratura"
-            },
-            "fingerbot_mode": {
-                "name": "Modalità",
-                "state": {
-                    "program": "Programma",
-                    "push": "Premi",
-                    "switch": "Interruttore"
-                }
-            },
-            "weather_delay": {
-                "name": "Ritardo meteorologico"
-            },
-            "smart_weather": {
-                "name": "Meteo intelligente"
-            },
-            "reminder_mode": {
-                "name": "Modalità promemoria",
-                "state": {
-                    "interval_reminder": "Intervallo",
-                    "schedule_reminder": "Pianificazione"
-                }
-            },
-            "temperature_unit": {
-                "name": "Unità di misura della temperatura"
-            }
-        },
-        "sensor": {
-            "alarm_lock": {
-                "name": "Allarme",
-                "state": {
-                    "wrong_finger": "Impronta errata",
-                    "wrong_password": "Password errata",
-                    "low_battery": "Batteria scarica",
-                    "power_off": "Spento"
-                }
-            },
-            "power_off": {
-                "name": "Spento"
-            },
-            "battery": {
-                "name": "Batteria"
-            },
-            "battery_charging": {
-                "name": "Ricarica batteria",
-                "state": {
-                    "charged": "Carica",
-                    "charging": "In carica",
-                    "not_charging": "Non in carica"
-                }
-            },
-            "battery_state": {
-                "name": "Stato della batteria",
-                "state": {
-                    "high": "Alto",
-                    "low": "Basso",
-                    "middle": "Medio",
-                    "normal": "Normale"
-                }
-            },
-            "carbon_dioxide": {
-                "name": "Anidride carbonica"
-            },
-            "carbon_dioxide_alarm": {
-                "name": "Livello di anidride carbonica",
-                "state": {
-                    "alarm": "Allarme",
-                    "normal": "Normale"
-                }
-            },
-            "day_usage_after_reset": {
-                "name": "Utilizzo giornaliero dopo il ripristino"
-            },
-            "day_water_usage": {
-                "name": "Consumo d'acqua giornaliero"
-            },
-            "flow_velocity": {
-                "name": "Portata"
-            },
-            "lock_door_status": {
-                "name": "Stato della porta",
-                "state": {
-                    "door_status_unknown": "Sconosciuto",
-                    "door_status_open": "Aperto",
-                    "door_status_closed": "Chiuso"
-                }
-            },
-            "humidity": {
-                "name": "Umidità"
-            },
-            "low_battery": {
-                "name": "Batteria scarica"
-            },
-            "moisture": {
-                "name": "Umidità del terreno"
-            },
-            "work_state": {
-                "name": "Stato di funzionamento"
-            },
-            "residual_electricity": {
-                "name": "Batteria"
-            },
-            "signal_strength": {
-                "name": "Potenza del segnale"
-            },
-            "temperature": {
-                "name": "Temperatura"
-            },
-            "time_left": {
-                "name": "Tempo di irrigazione rimanente"
-            },
-            "total_usage_after_reset": {
-                "name": "Consumo totale dopo il ripristino"
-            },
-            "use_time_z1": {
-                "name": "Ultimo tempo di irrigazione - Zona 1"
-            },
-            "use_time_z2": {
-                "name": "Ultimo tempo di irrigazione - Zona 2"
-            },
-            "use_time": {
-                "name": "Tempo di utilizzo accumulato"
-            },
-            "use_time_one": {
-                "name": "Ultimo tempo di irrigazione"
-            },
-            "water_intake": {
-                "name": "Consumo d'acqua"
-            },
-            "water_once": {
-                "name": "Consumo d'acqua dell'ultima sessione"
-            },
-            "water_use_data": {
-                "name": "Consumo d'acqua totale"
-            },
-            "wrong_finger": {
-                "name": "Impronta errata"
-            },
-            "wrong_password": {
-                "name": "Password errata"
-            },
-            "unlock_fingerprint": {
-                "name": "Ultima impronta digitale utilizzata"
-            },
-            "unlock_card": {
-                "name": "Ultima tessera utilizzata"
-            },
-            "unlock_password": {
-                "name": "Ultima password utilizzata"
-            },
-            "unlock_key": {
-                "name": "Ultima chiave utilizzata"
-            },
-            "unlock_dynamic": {
-                "name": "Ultima password dinamica utilizzata"
-            },
-            "unlock_ble": {
-                "name": "Ultimo Bluetooth utilizzato"
-            },
-            "unlock_app": {
-                "name": "Ultima app utilizzata"
-            },
-            "unlock_voice": {
-                "name": "Ultimo comando vocale utilizzato"
-            },
-            "unlock_temp_pwd": {
-                "name": "Ultima password temporanea utilizzata"
-            }
-        },
-        "switch": {
-            "antifreeze": {
-                "name": "Antigelo"
-            },
-            "carbon_dioxide_alarm_switch": {
-                "name": "Allarme abilitato"
-            },
-            "carbon_dioxide_severely_exceed_alarm": {
-                "name": "Allarme superamento grave"
-            },
-            "child_lock": {
-                "name": "Sicurezza bambini"
-            },
-            "lock_motor_state": {
-                "name": "Stato motore"
-            },
-            "low_battery_alarm": {
-                "name": "Allarme batteria scarica"
-            },
-            "manual_control": {
-                "name": "Controllo manuale"
-            },
-            "program": {
-                "name": "Programma"
-            },
-            "program_repeat_forever": {
-                "name": "Ripeti all'infinito"
-            },
-            "programming_mode": {
-                "name": "Modalità programmazione"
-            },
-            "programming_switch": {
-                "name": "Interruttore programmazione"
-            },
-            "reverse_positions": {
-                "name": "Posizioni invertite"
-            },
-            "switch": {
-                "name": "Interruttore"
-            },
-            "water_scale_proof": {
-                "name": "Anticalcare"
-            },
-            "water_valve": {
-                "name": "Valvola d'irrigazione"
-            },
-            "water_valve_z1": {
-                "name": "Valvola d'irrigazione - Zona 1"
-            },
-            "water_valve_z2": {
-                "name": "Valvola d'irrigazione - Zona 2"
-            },
-            "weather_switch": {
-                "name": "Interruttore meteo"
-            },
-            "window_check": {
-                "name": "Rilevamento finestra aperta"
-            }
-        },
-        "text": {
-            "program": {
-                "name": "Programma: posizione[/tempo];..."
-            }
-        },
-        "vacuum": {
-            "vacuum": {
-                "name": "Lavavetri"
-            }
-        }
+    "error": {
+      "device_not_registered": "Il dispositivo non è registrato nel cloud Tuya",
+      "invalid_auth": "Autenticazione non valida",
+      "login_error": "Errore di accesso ({code}): {msg}"
     },
-    "options": {
-        "error": {
-            "device_not_registered": "Il dispositivo non è registrato nel cloud Tuya",
-            "invalid_auth": "Autenticazione non valida",
-            "login_error": "Errore di accesso ({code}): {msg}"
+    "flow_title": "{name}",
+    "step": {
+      "device": {
+        "data": {
+          "address": "Dispositivo Tuya BLE"
         },
-        "step": {
-            "login": {
-                "data": {
-                    "access_id": "Tuya IoT Access ID",
-                    "access_secret": "Tuya IoT Access Secret",
-                    "country_code": "Paese",
-                    "password": "Password",
-                    "username": "Account"
-                },
-                "description": "Fai riferimento alla documentazione dell'integrazione Tuya per recuperare le credenziali cloud {url}\n\nInserisci le tue credenziali Tuya."
-            }
-        }
+        "description": "Seleziona il dispositivo Tuya BLE da configurare. Il dispositivo deve essere registrato nel cloud tramite l'applicazione mobile. Si consiglia di disassociare il dispositivo dal gateway Bluetooth Tuya, se presente."
+      },
+      "login": {
+        "data": {
+          "access_id": "Tuya IoT Access ID",
+          "access_secret": "Tuya IoT Access Secret",
+          "country_code": "Paese",
+          "password": "Password",
+          "username": "Account"
+        },
+        "description": "Tuya BLE richiede di ottenere la chiave di crittografia dal cloud Tuya. Quasi tutti i dispositivi devono accedere al cloud solo una volta durante la configurazione.\n\nFai riferimento alla documentazione dell'integrazione Tuya per recuperare le credenziali cloud {url}\n\nInserisci le tue credenziali Tuya."
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "fault": {
+        "name": "Guasto"
+      },
+      "lack_water": {
+        "name": "Mancanza d'acqua"
+      },
+      "low_battery": {
+        "name": "Batteria"
+      },
+      "lock_motor_state": {
+        "name": "Stato motore"
+      },
+      "low_temp": {
+        "name": "Bassa temperatura"
+      },
+      "motor_fault": {
+        "name": "Guasto motore"
+      },
+      "sensor_fault": {
+        "name": "Guasto sensore"
+      }
+    },
+    "button": {
+      "push": {
+        "name": "Premi"
+      },
+      "ble_unlock_check": {
+        "name": "Sblocca"
+      },
+      "bluetooth_unlock": {
+        "name": "Sblocca"
+      }
+    },
+    "event": {
+      "event": {
+        "name": "Evento"
+      }
+    },
+    "number": {
+      "ble_unlock_check": {
+        "name": "Sblocca"
+      },
+      "brightness": {
+        "name": "Luminosità"
+      },
+      "carbon_dioxide_alarm_level": {
+        "name": "Livello d'allarme"
+      },
+      "countdown": {
+        "name": "Durata irrigazione"
+      },
+      "countdown_duration": {
+        "name": "Durata irrigazione"
+      },
+      "countdown_duration_z1": {
+        "name": "Durata irrigazione - Zona 1"
+      },
+      "countdown_duration_z2": {
+        "name": "Durata irrigazione - Zona 2"
+      },
+      "down_position": {
+        "name": "Posizione giù"
+      },
+      "hold_time": {
+        "name": "Tempo di mantenimento"
+      },
+      "humidity_calibration": {
+        "name": "Calibrazione dell'umidità"
+      },
+      "program_idle_position": {
+        "name": "Posizione di riposo"
+      },
+      "program_repeats_count": {
+        "name": "Numero di ripetizioni"
+      },
+      "recommended_water_intake": {
+        "name": "Consumo d'acqua raccomandato"
+      },
+      "reporting_period": {
+        "name": "Periodo di segnalazione"
+      },
+      "temperature_calibration": {
+        "name": "Calibrazione della temperatura"
+      },
+      "up_position": {
+        "name": "Posizione su"
+      }
+    },
+    "select": {
+      "beep_volume": {
+        "name": "Volume serratura"
+      },
+      "language": {
+        "name": "Lingua serratura"
+      },
+      "fingerbot_mode": {
+        "name": "Modalità",
+        "state": {
+          "program": "Programma",
+          "push": "Premi",
+          "switch": "Interruttore"
+        }
+      },
+      "weather_delay": {
+        "name": "Ritardo meteorologico"
+      },
+      "smart_weather": {
+        "name": "Meteo intelligente"
+      },
+      "reminder_mode": {
+        "name": "Modalità promemoria",
+        "state": {
+          "interval_reminder": "Intervallo",
+          "schedule_reminder": "Pianificazione"
+        }
+      },
+      "temperature_unit": {
+        "name": "Unità di misura della temperatura"
+      }
+    },
+    "sensor": {
+      "alarm_lock": {
+        "name": "Allarme",
+        "state": {
+          "wrong_finger": "Impronta errata",
+          "wrong_password": "Password errata",
+          "low_battery": "Batteria scarica",
+          "power_off": "Spento"
+        }
+      },
+      "power_off": {
+        "name": "Spento"
+      },
+      "battery": {
+        "name": "Batteria"
+      },
+      "battery_charging": {
+        "name": "Ricarica batteria",
+        "state": {
+          "charged": "Carica",
+          "charging": "In carica",
+          "not_charging": "Non in carica"
+        }
+      },
+      "battery_state": {
+        "name": "Stato della batteria",
+        "state": {
+          "high": "Alto",
+          "low": "Basso",
+          "middle": "Medio",
+          "normal": "Normale"
+        }
+      },
+      "carbon_dioxide": {
+        "name": "Anidride carbonica"
+      },
+      "carbon_dioxide_alarm": {
+        "name": "Livello di anidride carbonica",
+        "state": {
+          "alarm": "Allarme",
+          "normal": "Normale"
+        }
+      },
+      "day_usage_after_reset": {
+        "name": "Utilizzo giornaliero dopo il ripristino"
+      },
+      "day_water_usage": {
+        "name": "Consumo d'acqua giornaliero"
+      },
+      "flow_velocity": {
+        "name": "Portata"
+      },
+      "lock_door_status": {
+        "name": "Stato della porta",
+        "state": {
+          "door_status_unknown": "Sconosciuto",
+          "door_status_open": "Aperto",
+          "door_status_closed": "Chiuso"
+        }
+      },
+      "humidity": {
+        "name": "Umidità"
+      },
+      "low_battery": {
+        "name": "Batteria scarica"
+      },
+      "moisture": {
+        "name": "Umidità del terreno"
+      },
+      "work_state": {
+        "name": "Stato di funzionamento"
+      },
+      "residual_electricity": {
+        "name": "Batteria"
+      },
+      "signal_strength": {
+        "name": "Potenza del segnale"
+      },
+      "temperature": {
+        "name": "Temperatura"
+      },
+      "time_left": {
+        "name": "Tempo di irrigazione rimanente"
+      },
+      "total_usage_after_reset": {
+        "name": "Consumo totale dopo il ripristino"
+      },
+      "use_time_z1": {
+        "name": "Ultimo tempo di irrigazione - Zona 1"
+      },
+      "use_time_z2": {
+        "name": "Ultimo tempo di irrigazione - Zona 2"
+      },
+      "use_time": {
+        "name": "Tempo di utilizzo accumulato"
+      },
+      "use_time_one": {
+        "name": "Ultimo tempo di irrigazione"
+      },
+      "water_intake": {
+        "name": "Consumo d'acqua"
+      },
+      "water_once": {
+        "name": "Consumo d'acqua dell'ultima sessione"
+      },
+      "water_use_data": {
+        "name": "Consumo d'acqua totale"
+      },
+      "wrong_finger": {
+        "name": "Impronta errata"
+      },
+      "wrong_password": {
+        "name": "Password errata"
+      },
+      "unlock_fingerprint": {
+        "name": "Ultima impronta digitale utilizzata"
+      },
+      "unlock_card": {
+        "name": "Ultima tessera utilizzata"
+      },
+      "unlock_password": {
+        "name": "Ultima password utilizzata"
+      },
+      "unlock_key": {
+        "name": "Ultima chiave utilizzata"
+      },
+      "unlock_dynamic": {
+        "name": "Ultima password dinamica utilizzata"
+      },
+      "unlock_ble": {
+        "name": "Ultimo Bluetooth utilizzato"
+      },
+      "unlock_app": {
+        "name": "Ultima app utilizzata"
+      },
+      "unlock_voice": {
+        "name": "Ultimo comando vocale utilizzato"
+      },
+      "unlock_temp_pwd": {
+        "name": "Ultima password temporanea utilizzata"
+      },
+      "weather_delay_remaining": {
+        "name": "Ritardo meteo rimanente"
+      },
+      "weather": {
+        "name": "Meteo",
+        "state": {
+          "sunny": "Soleggiato",
+          "cloudy": "Nuvoloso",
+          "rainy": "Piovoso",
+          "snowy": "Nevoso",
+          "null": "Non disponibile"
+        }
+      },
+      "spray_time_z1": {
+        "name": "Durata spruzzo - Zona 1"
+      },
+      "spray_time_z2": {
+        "name": "Durata spruzzo - Zona 2"
+      },
+      "work_state_z1": {
+        "name": "Stato operativo - Zona 1",
+        "state": {
+          "idle": "Inattivo",
+          "manual": "Manuale",
+          "spray": "Spruzzo",
+          "timing": "Programmato"
+        }
+      },
+      "work_state_z2": {
+        "name": "Stato operativo - Zona 2",
+        "state": {
+          "idle": "Inattivo",
+          "manual": "Manuale",
+          "spray": "Spruzzo",
+          "timing": "Programmato"
+        }
+      }
+    },
+    "switch": {
+      "antifreeze": {
+        "name": "Antigelo"
+      },
+      "carbon_dioxide_alarm_switch": {
+        "name": "Allarme abilitato"
+      },
+      "carbon_dioxide_severely_exceed_alarm": {
+        "name": "Allarme superamento grave"
+      },
+      "child_lock": {
+        "name": "Sicurezza bambini"
+      },
+      "lock_motor_state": {
+        "name": "Stato motore"
+      },
+      "low_battery_alarm": {
+        "name": "Allarme batteria scarica"
+      },
+      "manual_control": {
+        "name": "Controllo manuale"
+      },
+      "program": {
+        "name": "Programma"
+      },
+      "program_repeat_forever": {
+        "name": "Ripeti all'infinito"
+      },
+      "programming_mode": {
+        "name": "Modalità programmazione"
+      },
+      "programming_switch": {
+        "name": "Interruttore programmazione"
+      },
+      "reverse_positions": {
+        "name": "Posizioni invertite"
+      },
+      "switch": {
+        "name": "Interruttore"
+      },
+      "water_scale_proof": {
+        "name": "Anticalcare"
+      },
+      "water_valve": {
+        "name": "Valvola d'irrigazione"
+      },
+      "water_valve_z1": {
+        "name": "Valvola d'irrigazione - Zona 1"
+      },
+      "water_valve_z2": {
+        "name": "Valvola d'irrigazione - Zona 2"
+      },
+      "weather_switch": {
+        "name": "Interruttore meteo"
+      },
+      "window_check": {
+        "name": "Rilevamento finestra aperta"
+      }
+    },
+    "text": {
+      "program": {
+        "name": "Programma: posizione[/tempo];..."
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "Lavavetri"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_registered": "Il dispositivo non è registrato nel cloud Tuya",
+      "invalid_auth": "Autenticazione non valida",
+      "login_error": "Errore di accesso ({code}): {msg}"
+    },
+    "step": {
+      "login": {
+        "data": {
+          "access_id": "Tuya IoT Access ID",
+          "access_secret": "Tuya IoT Access Secret",
+          "country_code": "Paese",
+          "password": "Password",
+          "username": "Account"
+        },
+        "description": "Fai riferimento alla documentazione dell'integrazione Tuya per recuperare le credenziali cloud {url}\n\nInserisci le tue credenziali Tuya."
+      }
+    }
+  }
 }

--- a/custom_components/tuya_ble/translations/pt-BR.json
+++ b/custom_components/tuya_ble/translations/pt-BR.json
@@ -1,384 +1,421 @@
 {
-    "config": {
-        "abort": {
-            "no_unconfigured_devices": "Nenhum dispositivo não configurado encontrado."
-        },
-        "error": {
-            "device_not_registered": "O dispositivo não está registrado na nuvem da Tuya",
-            "invalid_auth": "Autenticação inválida",
-            "login_error": "Erro de login ({code}): {msg}"
-        },
-        "flow_title": "{name}",
-        "step": {
-            "device": {
-                "data": {
-                    "address": "Dispositivo Tuya BLE"
-                },
-                "description": "Selecione o dispositivo Tuya BLE para configurar. O dispositivo deve ser registrado na nuvem usando o aplicativo móvel. É melhor desvincular o dispositivo do gateway Bluetooth Tuya, se houver."
-            },
-            "login": {
-                "data": {
-                    "access_id": "ID de acesso Tuya IoT",
-                    "access_secret": "Segredo de acesso Tuya IoT",
-                    "country_code": "País",
-                    "password": "Senha",
-                    "username": "Conta"
-                },
-                "description": "O Tuya BLE requer a obtenção da chave de criptografia da nuvem da Tuya. Quase todos os dispositivos só precisam acessar a nuvem uma vez durante a configuração.\n\nConsulte a documentação da integração Tuya para recuperar as credenciais da nuvem {url}\n\nInsira suas credenciais da Tuya."
-            }
-        }
+  "config": {
+    "abort": {
+      "no_unconfigured_devices": "Nenhum dispositivo não configurado encontrado."
     },
-    "entity": {
-        "binary_sensor": {
-            "fault": {
-                "name": "Falha"
-            },
-            "lack_water": {
-                "name": "Falta de água"
-            },
-            "low_battery": {
-                "name": "Bateria"
-            },
-            "lock_motor_state": {
-                "name": "Estado do motor"
-            },
-            "low_temp": {
-                "name": "Baixa temperatura"
-            },
-            "motor_fault": {
-                "name": "Falha no motor"
-            },
-            "sensor_fault": {
-                "name": "Falha no sensor"
-            }
-        },
-        "button": {
-            "push": {
-                "name": "Pressionar"
-            },
-            "ble_unlock_check": {
-                "name": "Desbloquear"
-            },
-            "bluetooth_unlock": {
-                "name": "Desbloquear"
-            }
-        },
-        "event": {
-            "event": {
-                "name": "Evento"
-            }
-        },
-        "number": {
-            "ble_unlock_check": {
-                "name": "Desbloquear"
-            },
-            "brightness": {
-                "name": "Brilho"
-            },
-            "carbon_dioxide_alarm_level": {
-                "name": "Nível do alarme"
-            },
-            "countdown": {
-                "name": "Duração da irrigação"
-            },
-            "countdown_duration": {
-                "name": "Duração da irrigação"
-            },
-            "countdown_duration_z1": {
-                "name": "Duração da irrigação - Zona 1"
-            },
-            "countdown_duration_z2": {
-                "name": "Duração da irrigação - Zona 2"
-            },
-            "down_position": {
-                "name": "Posição para baixo"
-            },
-            "hold_time": {
-                "name": "Tempo de retenção"
-            },
-            "humidity_calibration": {
-                "name": "Calibração de umidade"
-            },
-            "program_idle_position": {
-                "name": "Posição de repouso"
-            },
-            "program_repeats_count": {
-                "name": "Número de repetições"
-            },
-            "recommended_water_intake": {
-                "name": "Consumo de água recomendado"
-            },
-            "reporting_period": {
-                "name": "Período de relatório"
-            },
-            "temperature_calibration": {
-                "name": "Calibração de temperatura"
-            },
-            "up_position": {
-                "name": "Posição para cima"
-            }
-        },
-        "select": {
-            "beep_volume": {
-                "name": "Volume da fechadura"
-            },
-            "language": {
-                "name": "Idioma da fechadura"
-            },
-            "fingerbot_mode": {
-                "name": "Modo",
-                "state": {
-                    "program": "Programa",
-                    "push": "Pressionar",
-                    "switch": "Interruptor"
-                }
-            },
-            "weather_delay": {
-                "name": "Atraso devido ao clima"
-            },
-            "smart_weather": {
-                "name": "Clima inteligente"
-            },
-            "reminder_mode": {
-                "name": "Modo de lembrete",
-                "state": {
-                    "interval_reminder": "Intervalo",
-                    "schedule_reminder": "Agendamento"
-                }
-            },
-            "temperature_unit": {
-                "name": "Unidade de temperatura"
-            }
-        },
-        "sensor": {
-            "alarm_lock": {
-                "name": "Alarme",
-                "state": {
-                    "wrong_finger": "Impressão digital incorreta",
-                    "wrong_password": "Senha incorreta",
-                    "low_battery": "Bateria fraca",
-                    "power_off": "Desligado"
-                }
-            },
-            "power_off": {
-                "name": "Desligado"
-            },
-            "battery": {
-                "name": "Bateria"
-            },
-            "battery_charging": {
-                "name": "Carregamento da bateria",
-                "state": {
-                    "charged": "Carregada",
-                    "charging": "Carregando",
-                    "not_charging": "Não está carregando"
-                }
-            },
-            "battery_state": {
-                "name": "Estado da bateria",
-                "state": {
-                    "high": "Alto",
-                    "low": "Baixo",
-                    "middle": "Médio",
-                    "normal": "Normal"
-                }
-            },
-            "carbon_dioxide": {
-                "name": "Dióxido de carbono"
-            },
-            "carbon_dioxide_alarm": {
-                "name": "Nivel de dióxido de carbono",
-                "state": {
-                    "alarm": "Alarme",
-                    "normal": "Normal"
-                }
-            },
-            "day_usage_after_reset": {
-                "name": "Uso diário após reinicialização"
-            },
-            "day_water_usage": {
-                "name": "Consumo de água diário"
-            },
-            "flow_velocity": {
-                "name": "Vazão"
-            },
-            "lock_door_status": {
-                "name": "Status da porta",
-                "state": {
-                    "door_status_unknown": "Desconhecido",
-                    "door_status_open": "Aberta",
-                    "door_status_closed": "Fechada"
-                }
-            },
-            "humidity": {
-                "name": "Umidade"
-            },
-            "low_battery": {
-                "name": "Bateria fraca"
-            },
-            "moisture": {
-                "name": "Umidade do solo"
-            },
-            "work_state": {
-                "name": "Estado de funcionamento"
-            },
-            "residual_electricity": {
-                "name": "Bateria"
-            },
-            "signal_strength": {
-                "name": "Força do sinal"
-            },
-            "temperature": {
-                "name": "Temperatura"
-            },
-            "time_left": {
-                "name": "Tempo de irrigação restante"
-            },
-            "total_usage_after_reset": {
-                "name": "Uso total após reinicialização"
-            },
-            "use_time_z1": {
-                "name": "Último tempo de irrigação - Zona 1"
-            },
-            "use_time_z2": {
-                "name": "Último tempo de irrigação - Zona 2"
-            },
-            "use_time": {
-                "name": "Tempo de uso acumulado"
-            },
-            "use_time_one": {
-                "name": "Último tempo de irrigação"
-            },
-            "water_intake": {
-                "name": "Consumo de água"
-            },
-            "water_once": {
-                "name": "Consumo de água da última sessão"
-            },
-            "water_use_data": {
-                "name": "Consumo total de água"
-            },
-            "wrong_finger": {
-                "name": "Impressão digital incorreta"
-            },
-            "wrong_password": {
-                "name": "Senha incorreta"
-            },
-            "unlock_fingerprint": {
-                "name": "Última digital utilizada"
-            },
-            "unlock_card": {
-                "name": "Último cartão utilizado"
-            },
-            "unlock_password": {
-                "name": "Última senha utilizada"
-            },
-            "unlock_key": {
-                "name": "Última chave utilizada"
-            },
-            "unlock_dynamic": {
-                "name": "Última senha dinâmica utilizada"
-            },
-            "unlock_ble": {
-                "name": "Último Bluetooth utilizado"
-            },
-            "unlock_app": {
-                "name": "Último aplicativo utilizado"
-            },
-            "unlock_voice": {
-                "name": "Último comando de voz utilizado"
-            },
-            "unlock_temp_pwd": {
-                "name": "Última senha temporária utilizada"
-            }
-        },
-        "switch": {
-            "antifreeze": {
-                "name": "Anticongelante"
-            },
-            "carbon_dioxide_alarm_switch": {
-                "name": "Alarme ativado"
-            },
-            "carbon_dioxide_severely_exceed_alarm": {
-                "name": "Alarme de limite gravemente excedido"
-            },
-            "child_lock": {
-                "name": "Bloqueio de crianças"
-            },
-            "lock_motor_state": {
-                "name": "Estado do motor"
-            },
-            "low_battery_alarm": {
-                "name": "Alarme de bateria fraca"
-            },
-            "manual_control": {
-                "name": "Controle manual"
-            },
-            "program": {
-                "name": "Programa"
-            },
-            "program_repeat_forever": {
-                "name": "Repetir indefinidamente"
-            },
-            "programming_mode": {
-                "name": "Modo de programação"
-            },
-            "programming_switch": {
-                "name": "Interruptor de programação"
-            },
-            "reverse_positions": {
-                "name": "Inverter posições"
-            },
-            "switch": {
-                "name": "Interruptor"
-            },
-            "water_scale_proof": {
-                "name": "Anticalcário"
-            },
-            "water_valve": {
-                "name": "Válvula de irrigação"
-            },
-            "water_valve_z1": {
-                "name": "Válvula de irrigação - Zona 1"
-            },
-            "water_valve_z2": {
-                "name": "Válvula de irrigação - Zona 2"
-            },
-            "weather_switch": {
-                "name": "Interruptor do clima"
-            },
-            "window_check": {
-                "name": "Detecção de janela"
-            }
-        },
-        "text": {
-            "program": {
-                "name": "Programa: posição[/tempo];..."
-            }
-        },
-        "vacuum": {
-            "vacuum": {
-                "name": "Limpador de janelas"
-            }
-        }
+    "error": {
+      "device_not_registered": "O dispositivo não está registrado na nuvem da Tuya",
+      "invalid_auth": "Autenticação inválida",
+      "login_error": "Erro de login ({code}): {msg}"
     },
-    "options": {
-        "error": {
-            "device_not_registered": "O dispositivo não está registrado na nuvem da Tuya",
-            "invalid_auth": "Autenticação inválida",
-            "login_error": "Erro de login ({code}): {msg}"
+    "flow_title": "{name}",
+    "step": {
+      "device": {
+        "data": {
+          "address": "Dispositivo Tuya BLE"
         },
-        "step": {
-            "login": {
-                "data": {
-                    "access_id": "ID de acesso Tuya IoT",
-                    "access_secret": "Segredo de acesso Tuya IoT",
-                    "country_code": "País",
-                    "password": "Senha",
-                    "username": "Conta"
-                },
-                "description": "Consulte a documentação da integração Tuya para recuperar as credenciais da nuvem {url}\n\nInsira suas credenciais da Tuya."
-            }
-        }
+        "description": "Selecione o dispositivo Tuya BLE para configurar. O dispositivo deve ser registrado na nuvem usando o aplicativo móvel. É melhor desvincular o dispositivo do gateway Bluetooth Tuya, se houver."
+      },
+      "login": {
+        "data": {
+          "access_id": "ID de acesso Tuya IoT",
+          "access_secret": "Segredo de acesso Tuya IoT",
+          "country_code": "País",
+          "password": "Senha",
+          "username": "Conta"
+        },
+        "description": "O Tuya BLE requer a obtenção da chave de criptografia da nuvem da Tuya. Quase todos os dispositivos só precisam acessar a nuvem uma vez durante a configuração.\n\nConsulte a documentação da integração Tuya para recuperar as credenciais da nuvem {url}\n\nInsira suas credenciais da Tuya."
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "fault": {
+        "name": "Falha"
+      },
+      "lack_water": {
+        "name": "Falta de água"
+      },
+      "low_battery": {
+        "name": "Bateria"
+      },
+      "lock_motor_state": {
+        "name": "Estado do motor"
+      },
+      "low_temp": {
+        "name": "Baixa temperatura"
+      },
+      "motor_fault": {
+        "name": "Falha no motor"
+      },
+      "sensor_fault": {
+        "name": "Falha no sensor"
+      }
+    },
+    "button": {
+      "push": {
+        "name": "Pressionar"
+      },
+      "ble_unlock_check": {
+        "name": "Desbloquear"
+      },
+      "bluetooth_unlock": {
+        "name": "Desbloquear"
+      }
+    },
+    "event": {
+      "event": {
+        "name": "Evento"
+      }
+    },
+    "number": {
+      "ble_unlock_check": {
+        "name": "Desbloquear"
+      },
+      "brightness": {
+        "name": "Brilho"
+      },
+      "carbon_dioxide_alarm_level": {
+        "name": "Nível do alarme"
+      },
+      "countdown": {
+        "name": "Duração da irrigação"
+      },
+      "countdown_duration": {
+        "name": "Duração da irrigação"
+      },
+      "countdown_duration_z1": {
+        "name": "Duração da irrigação - Zona 1"
+      },
+      "countdown_duration_z2": {
+        "name": "Duração da irrigação - Zona 2"
+      },
+      "down_position": {
+        "name": "Posição para baixo"
+      },
+      "hold_time": {
+        "name": "Tempo de retenção"
+      },
+      "humidity_calibration": {
+        "name": "Calibração de umidade"
+      },
+      "program_idle_position": {
+        "name": "Posição de repouso"
+      },
+      "program_repeats_count": {
+        "name": "Número de repetições"
+      },
+      "recommended_water_intake": {
+        "name": "Consumo de água recomendado"
+      },
+      "reporting_period": {
+        "name": "Período de relatório"
+      },
+      "temperature_calibration": {
+        "name": "Calibração de temperatura"
+      },
+      "up_position": {
+        "name": "Posição para cima"
+      }
+    },
+    "select": {
+      "beep_volume": {
+        "name": "Volume da fechadura"
+      },
+      "language": {
+        "name": "Idioma da fechadura"
+      },
+      "fingerbot_mode": {
+        "name": "Modo",
+        "state": {
+          "program": "Programa",
+          "push": "Pressionar",
+          "switch": "Interruptor"
+        }
+      },
+      "weather_delay": {
+        "name": "Atraso devido ao clima"
+      },
+      "smart_weather": {
+        "name": "Clima inteligente"
+      },
+      "reminder_mode": {
+        "name": "Modo de lembrete",
+        "state": {
+          "interval_reminder": "Intervalo",
+          "schedule_reminder": "Agendamento"
+        }
+      },
+      "temperature_unit": {
+        "name": "Unidade de temperatura"
+      }
+    },
+    "sensor": {
+      "alarm_lock": {
+        "name": "Alarme",
+        "state": {
+          "wrong_finger": "Impressão digital incorreta",
+          "wrong_password": "Senha incorreta",
+          "low_battery": "Bateria fraca",
+          "power_off": "Desligado"
+        }
+      },
+      "power_off": {
+        "name": "Desligado"
+      },
+      "battery": {
+        "name": "Bateria"
+      },
+      "battery_charging": {
+        "name": "Carregamento da bateria",
+        "state": {
+          "charged": "Carregada",
+          "charging": "Carregando",
+          "not_charging": "Não está carregando"
+        }
+      },
+      "battery_state": {
+        "name": "Estado da bateria",
+        "state": {
+          "high": "Alto",
+          "low": "Baixo",
+          "middle": "Médio",
+          "normal": "Normal"
+        }
+      },
+      "carbon_dioxide": {
+        "name": "Dióxido de carbono"
+      },
+      "carbon_dioxide_alarm": {
+        "name": "Nivel de dióxido de carbono",
+        "state": {
+          "alarm": "Alarme",
+          "normal": "Normal"
+        }
+      },
+      "day_usage_after_reset": {
+        "name": "Uso diário após reinicialização"
+      },
+      "day_water_usage": {
+        "name": "Consumo de água diário"
+      },
+      "flow_velocity": {
+        "name": "Vazão"
+      },
+      "lock_door_status": {
+        "name": "Status da porta",
+        "state": {
+          "door_status_unknown": "Desconhecido",
+          "door_status_open": "Aberta",
+          "door_status_closed": "Fechada"
+        }
+      },
+      "humidity": {
+        "name": "Umidade"
+      },
+      "low_battery": {
+        "name": "Bateria fraca"
+      },
+      "moisture": {
+        "name": "Umidade do solo"
+      },
+      "work_state": {
+        "name": "Estado de funcionamento"
+      },
+      "residual_electricity": {
+        "name": "Bateria"
+      },
+      "signal_strength": {
+        "name": "Força do sinal"
+      },
+      "temperature": {
+        "name": "Temperatura"
+      },
+      "time_left": {
+        "name": "Tempo de irrigação restante"
+      },
+      "total_usage_after_reset": {
+        "name": "Uso total após reinicialização"
+      },
+      "use_time_z1": {
+        "name": "Último tempo de irrigação - Zona 1"
+      },
+      "use_time_z2": {
+        "name": "Último tempo de irrigação - Zona 2"
+      },
+      "use_time": {
+        "name": "Tempo de uso acumulado"
+      },
+      "use_time_one": {
+        "name": "Último tempo de irrigação"
+      },
+      "water_intake": {
+        "name": "Consumo de água"
+      },
+      "water_once": {
+        "name": "Consumo de água da última sessão"
+      },
+      "water_use_data": {
+        "name": "Consumo total de água"
+      },
+      "wrong_finger": {
+        "name": "Impressão digital incorreta"
+      },
+      "wrong_password": {
+        "name": "Senha incorreta"
+      },
+      "unlock_fingerprint": {
+        "name": "Última digital utilizada"
+      },
+      "unlock_card": {
+        "name": "Último cartão utilizado"
+      },
+      "unlock_password": {
+        "name": "Última senha utilizada"
+      },
+      "unlock_key": {
+        "name": "Última chave utilizada"
+      },
+      "unlock_dynamic": {
+        "name": "Última senha dinâmica utilizada"
+      },
+      "unlock_ble": {
+        "name": "Último Bluetooth utilizado"
+      },
+      "unlock_app": {
+        "name": "Último aplicativo utilizado"
+      },
+      "unlock_voice": {
+        "name": "Último comando de voz utilizado"
+      },
+      "unlock_temp_pwd": {
+        "name": "Última senha temporária utilizada"
+      },
+      "weather_delay_remaining": {
+        "name": "Atraso climático restante"
+      },
+      "weather": {
+        "name": "Clima",
+        "state": {
+          "sunny": "Ensolarado",
+          "cloudy": "Nublado",
+          "rainy": "Chuvoso",
+          "snowy": "Nevado",
+          "null": "Indisponível"
+        }
+      },
+      "spray_time_z1": {
+        "name": "Duração do spray - Zona 1"
+      },
+      "spray_time_z2": {
+        "name": "Duração do spray - Zona 2"
+      },
+      "work_state_z1": {
+        "name": "Estado de trabalho - Zona 1",
+        "state": {
+          "idle": "Ocioso",
+          "manual": "Manual",
+          "spray": "Spray",
+          "timing": "Agendado"
+        }
+      },
+      "work_state_z2": {
+        "name": "Estado de trabalho - Zona 2",
+        "state": {
+          "idle": "Ocioso",
+          "manual": "Manual",
+          "spray": "Spray",
+          "timing": "Agendado"
+        }
+      }
+    },
+    "switch": {
+      "antifreeze": {
+        "name": "Anticongelante"
+      },
+      "carbon_dioxide_alarm_switch": {
+        "name": "Alarme ativado"
+      },
+      "carbon_dioxide_severely_exceed_alarm": {
+        "name": "Alarme de limite gravemente excedido"
+      },
+      "child_lock": {
+        "name": "Bloqueio de crianças"
+      },
+      "lock_motor_state": {
+        "name": "Estado do motor"
+      },
+      "low_battery_alarm": {
+        "name": "Alarme de bateria fraca"
+      },
+      "manual_control": {
+        "name": "Controle manual"
+      },
+      "program": {
+        "name": "Programa"
+      },
+      "program_repeat_forever": {
+        "name": "Repetir indefinidamente"
+      },
+      "programming_mode": {
+        "name": "Modo de programação"
+      },
+      "programming_switch": {
+        "name": "Interruptor de programação"
+      },
+      "reverse_positions": {
+        "name": "Inverter posições"
+      },
+      "switch": {
+        "name": "Interruptor"
+      },
+      "water_scale_proof": {
+        "name": "Anticalcário"
+      },
+      "water_valve": {
+        "name": "Válvula de irrigação"
+      },
+      "water_valve_z1": {
+        "name": "Válvula de irrigação - Zona 1"
+      },
+      "water_valve_z2": {
+        "name": "Válvula de irrigação - Zona 2"
+      },
+      "weather_switch": {
+        "name": "Interruptor do clima"
+      },
+      "window_check": {
+        "name": "Detecção de janela"
+      }
+    },
+    "text": {
+      "program": {
+        "name": "Programa: posição[/tempo];..."
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "Limpador de janelas"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_registered": "O dispositivo não está registrado na nuvem da Tuya",
+      "invalid_auth": "Autenticação inválida",
+      "login_error": "Erro de login ({code}): {msg}"
+    },
+    "step": {
+      "login": {
+        "data": {
+          "access_id": "ID de acesso Tuya IoT",
+          "access_secret": "Segredo de acesso Tuya IoT",
+          "country_code": "País",
+          "password": "Senha",
+          "username": "Conta"
+        },
+        "description": "Consulte a documentação da integração Tuya para recuperar as credenciais da nuvem {url}\n\nInsira suas credenciais da Tuya."
+      }
+    }
+  }
 }

--- a/custom_components/tuya_ble/translations/zh-Hans.json
+++ b/custom_components/tuya_ble/translations/zh-Hans.json
@@ -1,384 +1,421 @@
 {
-    "config": {
-        "abort": {
-            "no_unconfigured_devices": "未找到未配置的的设备。"
-        },
-        "error": {
-            "device_not_registered": "设备未在涂鸦云端注册",
-            "invalid_auth": "身份验证无效",
-            "login_error": "登录错误 ({code}): {msg}"
-        },
-        "flow_title": "{name}",
-        "step": {
-            "device": {
-                "data": {
-                    "address": "涂鸦 BLE 设备"
-                },
-                "description": "选择要设置的涂鸦 BLE 设备。设备必须使用手机应用在云端进行注册。最好将设备从涂鸦蓝牙网关（如果有）中解绑。"
-            },
-            "login": {
-                "data": {
-                    "access_id": "涂鸦 IoT Access ID",
-                    "access_secret": "涂鸦 IoT Access Secret",
-                    "country_code": "国家/地区",
-                    "password": "密码",
-                    "username": "账号"
-                },
-                "description": "涂鸦 BLE 需要从涂鸦云端获取加密密钥。几乎所有设备在设置期间只需访问云端一次。\n\n请参考涂鸦集成的文档来检索云端凭据 {url}\n\n输入您的涂鸦凭据。"
-            }
-        }
+  "config": {
+    "abort": {
+      "no_unconfigured_devices": "未找到未配置的的设备。"
     },
-    "entity": {
-        "binary_sensor": {
-            "fault": {
-                "name": "故障"
-            },
-            "lack_water": {
-                "name": "缺水"
-            },
-            "low_battery": {
-                "name": "电量"
-            },
-            "lock_motor_state": {
-                "name": "电机状态"
-            },
-            "low_temp": {
-                "name": "低温"
-            },
-            "motor_fault": {
-                "name": "电机故障"
-            },
-            "sensor_fault": {
-                "name": "传感器故障"
-            }
-        },
-        "button": {
-            "push": {
-                "name": "按下"
-            },
-            "ble_unlock_check": {
-                "name": "解锁"
-            },
-            "bluetooth_unlock": {
-                "name": "解锁"
-            }
-        },
-        "event": {
-            "event": {
-                "name": "事件"
-            }
-        },
-        "number": {
-            "ble_unlock_check": {
-                "name": "解锁"
-            },
-            "brightness": {
-                "name": "亮度"
-            },
-            "carbon_dioxide_alarm_level": {
-                "name": "报警级别"
-            },
-            "countdown": {
-                "name": "灌溉时长"
-            },
-            "countdown_duration": {
-                "name": "灌溉时长"
-            },
-            "countdown_duration_z1": {
-                "name": "灌溉时长 - 区域 1"
-            },
-            "countdown_duration_z2": {
-                "name": "灌溉时长 - 区域 2"
-            },
-            "down_position": {
-                "name": "下限位置"
-            },
-            "hold_time": {
-                "name": "保持时间"
-            },
-            "humidity_calibration": {
-                "name": "湿度校准"
-            },
-            "program_idle_position": {
-                "name": "空闲位置"
-            },
-            "program_repeats_count": {
-                "name": "重复次数"
-            },
-            "recommended_water_intake": {
-                "name": "推荐摄水量"
-            },
-            "reporting_period": {
-                "name": "上报周期"
-            },
-            "temperature_calibration": {
-                "name": "温度校准"
-            },
-            "up_position": {
-                "name": "上限位置"
-            }
-        },
-        "select": {
-            "beep_volume": {
-                "name": "锁音量"
-            },
-            "language": {
-                "name": "锁语言"
-            },
-            "fingerbot_mode": {
-                "name": "模式",
-                "state": {
-                    "program": "程序",
-                    "push": "按下",
-                    "switch": "开关"
-                }
-            },
-            "weather_delay": {
-                "name": "天气延时"
-            },
-            "smart_weather": {
-                "name": "智能天气"
-            },
-            "reminder_mode": {
-                "name": "提醒模式",
-                "state": {
-                    "interval_reminder": "间隔",
-                    "schedule_reminder": "日程"
-                }
-            },
-            "temperature_unit": {
-                "name": "温度单位"
-            }
-        },
-        "sensor": {
-            "alarm_lock": {
-                "name": "报警",
-                "state": {
-                    "wrong_finger": "指纹错误",
-                    "wrong_password": "密码错误",
-                    "low_battery": "低电量",
-                    "power_off": "关机"
-                }
-            },
-            "power_off": {
-                "name": "关机"
-            },
-            "battery": {
-                "name": "电量"
-            },
-            "battery_charging": {
-                "name": "电池充电",
-                "state": {
-                    "charged": "已充满",
-                    "charging": "正在充电",
-                    "not_charging": "未充电"
-                }
-            },
-            "battery_state": {
-                "name": "电池状态",
-                "state": {
-                    "high": "高",
-                    "low": "低",
-                    "middle": "中",
-                    "normal": "正常"
-                }
-            },
-            "carbon_dioxide": {
-                "name": "二氧化碳"
-            },
-            "carbon_dioxide_alarm": {
-                "name": "二氧化碳浓度",
-                "state": {
-                    "alarm": "报警",
-                    "normal": "正常"
-                }
-            },
-            "day_usage_after_reset": {
-                "name": "重置后的每日用量"
-            },
-            "day_water_usage": {
-                "name": "每日用水量"
-            },
-            "flow_velocity": {
-                "name": "流速"
-            },
-            "lock_door_status": {
-                "name": "门状态",
-                "state": {
-                    "door_status_unknown": "未知",
-                    "door_status_open": "开启",
-                    "door_status_closed": "关闭"
-                }
-            },
-            "humidity": {
-                "name": "湿度"
-            },
-            "low_battery": {
-                "name": "低电量"
-            },
-            "moisture": {
-                "name": "水分"
-            },
-            "work_state": {
-                "name": "工作状态"
-            },
-            "residual_electricity": {
-                "name": "电量"
-            },
-            "signal_strength": {
-                "name": "信号强度"
-            },
-            "temperature": {
-                "name": "温度"
-            },
-            "time_left": {
-                "name": "剩余灌溉时间"
-            },
-            "total_usage_after_reset": {
-                "name": "重置后的总用量"
-            },
-            "use_time_z1": {
-                "name": "上次灌溉时间 - 区域 1"
-            },
-            "use_time_z2": {
-                "name": "上次灌溉时间 - 区域 2"
-            },
-            "use_time": {
-                "name": "累计使用时间"
-            },
-            "use_time_one": {
-                "name": "上次灌溉时间"
-            },
-            "water_intake": {
-                "name": "摄水量"
-            },
-            "water_once": {
-                "name": "上次用水量"
-            },
-            "water_use_data": {
-                "name": "总用水量"
-            },
-            "wrong_finger": {
-                "name": "指纹错误"
-            },
-            "wrong_password": {
-                "name": "密码错误"
-            },
-            "unlock_fingerprint": {
-                "name": "上次使用的指纹"
-            },
-            "unlock_card": {
-                "name": "上次使用的卡片"
-            },
-            "unlock_password": {
-                "name": "上次使用的密码"
-            },
-            "unlock_key": {
-                "name": "上次使用的钥匙"
-            },
-            "unlock_dynamic": {
-                "name": "上次使用的动态密码"
-            },
-            "unlock_ble": {
-                "name": "上次使用的蓝牙"
-            },
-            "unlock_app": {
-                "name": "上次使用的应用"
-            },
-            "unlock_voice": {
-                "name": "上次使用的语音"
-            },
-            "unlock_temp_pwd": {
-                "name": "上次使用的临时密码"
-            }
-        },
-        "switch": {
-            "antifreeze": {
-                "name": "防冻"
-            },
-            "carbon_dioxide_alarm_switch": {
-                "name": "报警已启用"
-            },
-            "carbon_dioxide_severely_exceed_alarm": {
-                "name": "严重超标报警"
-            },
-            "child_lock": {
-                "name": "童锁"
-            },
-            "lock_motor_state": {
-                "name": "电机状态"
-            },
-            "low_battery_alarm": {
-                "name": "低电量报警"
-            },
-            "manual_control": {
-                "name": "手动控制"
-            },
-            "program": {
-                "name": "程序"
-            },
-            "program_repeat_forever": {
-                "name": "无限重复"
-            },
-            "programming_mode": {
-                "name": "编程模式"
-            },
-            "programming_switch": {
-                "name": "编程开关"
-            },
-            "reverse_positions": {
-                "name": "反向位置"
-            },
-            "switch": {
-                "name": "开关"
-            },
-            "water_scale_proof": {
-                "name": "防垢"
-            },
-            "water_valve": {
-                "name": "灌溉阀"
-            },
-            "water_valve_z1": {
-                "name": "灌溉阀 - 区域 1"
-            },
-            "water_valve_z2": {
-                "name": "灌溉阀 - 区域 2"
-            },
-            "weather_switch": {
-                "name": "天气开关"
-            },
-            "window_check": {
-                "name": "开窗检测"
-            }
-        },
-        "text": {
-            "program": {
-                "name": "程序：位置[/时间];..."
-            }
-        },
-        "vacuum": {
-            "vacuum": {
-                "name": "擦窗机器人"
-            }
-        }
+    "error": {
+      "device_not_registered": "设备未在涂鸦云端注册",
+      "invalid_auth": "身份验证无效",
+      "login_error": "登录错误 ({code}): {msg}"
     },
-    "options": {
-        "error": {
-            "device_not_registered": "设备未在涂鸦云端注册",
-            "invalid_auth": "身份验证无效",
-            "login_error": "登录错误 ({code}): {msg}"
+    "flow_title": "{name}",
+    "step": {
+      "device": {
+        "data": {
+          "address": "涂鸦 BLE 设备"
         },
-        "step": {
-            "login": {
-                "data": {
-                    "access_id": "涂鸦 IoT Access ID",
-                    "access_secret": "涂鸦 IoT Access Secret",
-                    "country_code": "国家/地区",
-                    "password": "密码",
-                    "username": "账号"
-                },
-                "description": "请参考涂鸦集成的文档来检索云端凭据 {url}\n\n输入您的涂鸦凭据。"
-            }
-        }
+        "description": "选择要设置的涂鸦 BLE 设备。设备必须使用手机应用在云端进行注册。最好将设备从涂鸦蓝牙网关（如果有）中解绑。"
+      },
+      "login": {
+        "data": {
+          "access_id": "涂鸦 IoT Access ID",
+          "access_secret": "涂鸦 IoT Access Secret",
+          "country_code": "国家/地区",
+          "password": "密码",
+          "username": "账号"
+        },
+        "description": "涂鸦 BLE 需要从涂鸦云端获取加密密钥。几乎所有设备在设置期间只需访问云端一次。\n\n请参考涂鸦集成的文档来检索云端凭据 {url}\n\n输入您的涂鸦凭据。"
+      }
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "fault": {
+        "name": "故障"
+      },
+      "lack_water": {
+        "name": "缺水"
+      },
+      "low_battery": {
+        "name": "电量"
+      },
+      "lock_motor_state": {
+        "name": "电机状态"
+      },
+      "low_temp": {
+        "name": "低温"
+      },
+      "motor_fault": {
+        "name": "电机故障"
+      },
+      "sensor_fault": {
+        "name": "传感器故障"
+      }
+    },
+    "button": {
+      "push": {
+        "name": "按下"
+      },
+      "ble_unlock_check": {
+        "name": "解锁"
+      },
+      "bluetooth_unlock": {
+        "name": "解锁"
+      }
+    },
+    "event": {
+      "event": {
+        "name": "事件"
+      }
+    },
+    "number": {
+      "ble_unlock_check": {
+        "name": "解锁"
+      },
+      "brightness": {
+        "name": "亮度"
+      },
+      "carbon_dioxide_alarm_level": {
+        "name": "报警级别"
+      },
+      "countdown": {
+        "name": "灌溉时长"
+      },
+      "countdown_duration": {
+        "name": "灌溉时长"
+      },
+      "countdown_duration_z1": {
+        "name": "灌溉时长 - 区域 1"
+      },
+      "countdown_duration_z2": {
+        "name": "灌溉时长 - 区域 2"
+      },
+      "down_position": {
+        "name": "下限位置"
+      },
+      "hold_time": {
+        "name": "保持时间"
+      },
+      "humidity_calibration": {
+        "name": "湿度校准"
+      },
+      "program_idle_position": {
+        "name": "空闲位置"
+      },
+      "program_repeats_count": {
+        "name": "重复次数"
+      },
+      "recommended_water_intake": {
+        "name": "推荐摄水量"
+      },
+      "reporting_period": {
+        "name": "上报周期"
+      },
+      "temperature_calibration": {
+        "name": "温度校准"
+      },
+      "up_position": {
+        "name": "上限位置"
+      }
+    },
+    "select": {
+      "beep_volume": {
+        "name": "锁音量"
+      },
+      "language": {
+        "name": "锁语言"
+      },
+      "fingerbot_mode": {
+        "name": "模式",
+        "state": {
+          "program": "程序",
+          "push": "按下",
+          "switch": "开关"
+        }
+      },
+      "weather_delay": {
+        "name": "天气延时"
+      },
+      "smart_weather": {
+        "name": "智能天气"
+      },
+      "reminder_mode": {
+        "name": "提醒模式",
+        "state": {
+          "interval_reminder": "间隔",
+          "schedule_reminder": "日程"
+        }
+      },
+      "temperature_unit": {
+        "name": "温度单位"
+      }
+    },
+    "sensor": {
+      "alarm_lock": {
+        "name": "报警",
+        "state": {
+          "wrong_finger": "指纹错误",
+          "wrong_password": "密码错误",
+          "low_battery": "低电量",
+          "power_off": "关机"
+        }
+      },
+      "power_off": {
+        "name": "关机"
+      },
+      "battery": {
+        "name": "电量"
+      },
+      "battery_charging": {
+        "name": "电池充电",
+        "state": {
+          "charged": "已充满",
+          "charging": "正在充电",
+          "not_charging": "未充电"
+        }
+      },
+      "battery_state": {
+        "name": "电池状态",
+        "state": {
+          "high": "高",
+          "low": "低",
+          "middle": "中",
+          "normal": "正常"
+        }
+      },
+      "carbon_dioxide": {
+        "name": "二氧化碳"
+      },
+      "carbon_dioxide_alarm": {
+        "name": "二氧化碳浓度",
+        "state": {
+          "alarm": "报警",
+          "normal": "正常"
+        }
+      },
+      "day_usage_after_reset": {
+        "name": "重置后的每日用量"
+      },
+      "day_water_usage": {
+        "name": "每日用水量"
+      },
+      "flow_velocity": {
+        "name": "流速"
+      },
+      "lock_door_status": {
+        "name": "门状态",
+        "state": {
+          "door_status_unknown": "未知",
+          "door_status_open": "开启",
+          "door_status_closed": "关闭"
+        }
+      },
+      "humidity": {
+        "name": "湿度"
+      },
+      "low_battery": {
+        "name": "低电量"
+      },
+      "moisture": {
+        "name": "水分"
+      },
+      "work_state": {
+        "name": "工作状态"
+      },
+      "residual_electricity": {
+        "name": "电量"
+      },
+      "signal_strength": {
+        "name": "信号强度"
+      },
+      "temperature": {
+        "name": "温度"
+      },
+      "time_left": {
+        "name": "剩余灌溉时间"
+      },
+      "total_usage_after_reset": {
+        "name": "重置后的总用量"
+      },
+      "use_time_z1": {
+        "name": "上次灌溉时间 - 区域 1"
+      },
+      "use_time_z2": {
+        "name": "上次灌溉时间 - 区域 2"
+      },
+      "use_time": {
+        "name": "累计使用时间"
+      },
+      "use_time_one": {
+        "name": "上次灌溉时间"
+      },
+      "water_intake": {
+        "name": "摄水量"
+      },
+      "water_once": {
+        "name": "上次用水量"
+      },
+      "water_use_data": {
+        "name": "总用水量"
+      },
+      "wrong_finger": {
+        "name": "指纹错误"
+      },
+      "wrong_password": {
+        "name": "密码错误"
+      },
+      "unlock_fingerprint": {
+        "name": "上次使用的指纹"
+      },
+      "unlock_card": {
+        "name": "上次使用的卡片"
+      },
+      "unlock_password": {
+        "name": "上次使用的密码"
+      },
+      "unlock_key": {
+        "name": "上次使用的钥匙"
+      },
+      "unlock_dynamic": {
+        "name": "上次使用的动态密码"
+      },
+      "unlock_ble": {
+        "name": "上次使用的蓝牙"
+      },
+      "unlock_app": {
+        "name": "上次使用的应用"
+      },
+      "unlock_voice": {
+        "name": "上次使用的语音"
+      },
+      "unlock_temp_pwd": {
+        "name": "上次使用的临时密码"
+      },
+      "weather_delay_remaining": {
+        "name": "天气延时剩余时间"
+      },
+      "weather": {
+        "name": "天气",
+        "state": {
+          "sunny": "晴天",
+          "cloudy": "多云",
+          "rainy": "雨天",
+          "snowy": "雪天",
+          "null": "不可用"
+        }
+      },
+      "spray_time_z1": {
+        "name": "喷雾时长 - 1区"
+      },
+      "spray_time_z2": {
+        "name": "喷雾时长 - 2区"
+      },
+      "work_state_z1": {
+        "name": "工作状态 - 1区",
+        "state": {
+          "idle": "空闲",
+          "manual": "手动",
+          "spray": "喷雾",
+          "timing": "定时"
+        }
+      },
+      "work_state_z2": {
+        "name": "工作状态 - 2区",
+        "state": {
+          "idle": "空闲",
+          "manual": "手动",
+          "spray": "喷雾",
+          "timing": "定时"
+        }
+      }
+    },
+    "switch": {
+      "antifreeze": {
+        "name": "防冻"
+      },
+      "carbon_dioxide_alarm_switch": {
+        "name": "报警已启用"
+      },
+      "carbon_dioxide_severely_exceed_alarm": {
+        "name": "严重超标报警"
+      },
+      "child_lock": {
+        "name": "童锁"
+      },
+      "lock_motor_state": {
+        "name": "电机状态"
+      },
+      "low_battery_alarm": {
+        "name": "低电量报警"
+      },
+      "manual_control": {
+        "name": "手动控制"
+      },
+      "program": {
+        "name": "程序"
+      },
+      "program_repeat_forever": {
+        "name": "无限重复"
+      },
+      "programming_mode": {
+        "name": "编程模式"
+      },
+      "programming_switch": {
+        "name": "编程开关"
+      },
+      "reverse_positions": {
+        "name": "反向位置"
+      },
+      "switch": {
+        "name": "开关"
+      },
+      "water_scale_proof": {
+        "name": "防垢"
+      },
+      "water_valve": {
+        "name": "灌溉阀"
+      },
+      "water_valve_z1": {
+        "name": "灌溉阀 - 区域 1"
+      },
+      "water_valve_z2": {
+        "name": "灌溉阀 - 区域 2"
+      },
+      "weather_switch": {
+        "name": "天气开关"
+      },
+      "window_check": {
+        "name": "开窗检测"
+      }
+    },
+    "text": {
+      "program": {
+        "name": "程序：位置[/时间];..."
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "擦窗机器人"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_registered": "设备未在涂鸦云端注册",
+      "invalid_auth": "身份验证无效",
+      "login_error": "登录错误 ({code}): {msg}"
+    },
+    "step": {
+      "login": {
+        "data": {
+          "access_id": "涂鸦 IoT Access ID",
+          "access_secret": "涂鸦 IoT Access Secret",
+          "country_code": "国家/地区",
+          "password": "密码",
+          "username": "账号"
+        },
+        "description": "请参考涂鸦集成的文档来检索云端凭据 {url}\n\n输入您的涂鸦凭据。"
+      }
+    }
+  }
 }

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -101,3 +101,71 @@ async def test_select(hass: HomeAssistant) -> None:
     device._send_datapoints.assert_called_once_with([31])
     assert device.datapoints[31].value == 3
     assert entity.current_option == "high"
+
+
+async def test_select_getter_setter(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    product_info = TuyaBLEProductInfo("Fake Select Product")
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map our select entity with custom getter and setter
+    getter_mock = Mock(return_value="custom_val")
+    setter_mock = Mock()
+    mapping = TuyaBLESelectMapping(
+        dp_id=31,
+        description=SelectEntityDescription(
+            key="test_select",
+            options=["custom_val", "other_val"],
+        ),
+        force_add=True,
+        getter=getter_mock,
+        setter=setter_mock,
+    )
+
+    entity = TuyaBLESelect(
+        hass, coordinator, device, product_info, mapping
+    )
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    coordinator._async_handle_connect()
+    assert entity.current_option == "custom_val"
+    getter_mock.assert_called_with(entity, product_info)
+
+    # Call select_option
+    entity.select_option("other_val")
+    await hass.async_block_till_done()
+    setter_mock.assert_called_once_with(entity, product_info, "other_val")


### PR DESCRIPTION
Implemented full support for HCT-626 Dual Water Timer (smd9kj1n) under the sfkzq category. Supported all datapoints across dual zones with bidirectional custom conversions, complete local translations, and extensive unit tests.

---
*PR created automatically by Jules for task [141607103738293115](https://jules.google.com/task/141607103738293115) started by @CloCkWeRX*