### PR TITLE
fix(device): add Guard Dog Security BS_PLD01 smart lock support (fix #251)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ The integration works locally, but connection to Tuya BLE device requires device
       <td>—</td>
     </tr>
     <tr>
-      <td rowspan="21"><strong>Smart Locks</strong></td>
-      <td rowspan="21"><code>ms</code>, <code>jtmspro</code></td>
+      <td rowspan="22"><strong>Smart Locks</strong></td>
+      <td rowspan="22"><code>ms</code>, <code>jtmspro</code></td>
       <td>Smart Lock</td>
       <td><code>ludzroix</code>, <code>isk2p555</code>, <code>gumrixyt</code>, <code>uamrw6h3</code>, <code>sidhzylo</code>, <code>mqc2hevy</code>, <code>7a4xvbtt</code></td>
       <td>—</td>
@@ -136,6 +136,11 @@ The integration works locally, but connection to Tuya BLE device requires device
     <tr>
       <td>Foxgard Smart Fingerprint Door Lock</td>
       <td><code>99gv5nmz</code></td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td>Guard Dog Security Smart Lock (BS_PLD01)</td>
+      <td><code>wgv4haro</code></td>
       <td>—</td>
     </tr>
     <tr>

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -228,7 +228,7 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
     "ms": TuyaBLECategoryButtonMapping(
         products={
             **dict.fromkeys(
-                ["okkyfgfs", "k53ok3u9", "sidhzylo", "a6nttc41"],  # Smart Lock
+                ["okkyfgfs", "k53ok3u9", "sidhzylo", "a6nttc41", "wgv4haro"],  # Smart Lock
                 [
                     TuyaBLEButtonMapping(
                         dp_id=6,

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -228,7 +228,13 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
     "ms": TuyaBLECategoryButtonMapping(
         products={
             **dict.fromkeys(
-                ["okkyfgfs", "k53ok3u9", "sidhzylo", "a6nttc41", "wgv4haro"],  # Smart Lock
+                [
+                    "okkyfgfs",
+                    "k53ok3u9",
+                    "sidhzylo",
+                    "a6nttc41",
+                    "wgv4haro",
+                ],  # Smart Lock
                 [
                     TuyaBLEButtonMapping(
                         dp_id=6,

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -402,6 +402,11 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                 manufacturer="Foxgard",
                 lock=1,
             ),
+            "wgv4haro": TuyaBLEProductInfo(
+                name="Guard Dog Security Smart Lock",
+                manufacturer="Guard Dog Security",
+                lock=1,
+            ),
         },
     ),
     "dcb": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -288,6 +288,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                     "okkyfgfs",
                     "sidhzylo",
                     "7a4xvbtt",
+                    "wgv4haro",
                 ],  # Smart Lock
                 [
                     TuyaBLESelectMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -213,7 +213,6 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     "7a4xvbtt",
                     "6fibxtph",
                     "99gv5nmz",
-                    "wgv4haro",
                 ],  # Smart Lock
                 [
                     TuyaBLEAlarmLockStateMapping(dp_id=21),
@@ -233,6 +232,52 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     ),
                 ],
             ),
+            "wgv4haro": [
+                TuyaBLEAlarmLockStateMapping(dp_id=21),
+                TuyaBLEBatteryMapping(dp_id=8),
+                TuyaBLESensorMapping(
+                    dp_id=12,  # Retrieve last fingerprint used
+                    description=SensorEntityDescription(
+                        key="unlock_fingerprint",
+                        icon="mdi:fingerprint",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=13,  # Retrieve last password used
+                    description=SensorEntityDescription(
+                        key="unlock_password",
+                        icon="mdi:keyboard-outline",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=14,  # Retrieve last dynamic password used
+                    description=SensorEntityDescription(
+                        key="unlock_dynamic",
+                        icon="mdi:cellphone-key",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=19,  # Retrieve last BLE used
+                    description=SensorEntityDescription(
+                        key="unlock_ble",
+                        icon="mdi:bluetooth",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=55,  # Retrieve last temporary password unlock used
+                    description=SensorEntityDescription(
+                        key="unlock_temp_pwd",
+                        icon="mdi:lock-clock",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=62,  # Retrieve last app unlock used
+                    description=SensorEntityDescription(
+                        key="unlock_app",
+                        icon="mdi:cellphone-lock",
+                    ),
+                ),
+            ],
             "mqc2hevy": [  # Smart Lock - YSG_T8_8G_htr
                 # TODO: TuyaBLEAlarmLockStateMapping(dp_id=21) ?
                 TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -213,6 +213,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     "7a4xvbtt",
                     "6fibxtph",
                     "99gv5nmz",
+                    "wgv4haro",
                 ],  # Smart Lock
                 [
                     TuyaBLEAlarmLockStateMapping(dp_id=21),

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -306,6 +306,7 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     "gumrixyt",
                     "sidhzylo",
                     "7a4xvbtt",
+                    "wgv4haro",
                 ],  # Smart Lock
                 [TuyaLockMotorStateMapping(dp_id=47)],
             ),

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -306,7 +306,6 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     "gumrixyt",
                     "sidhzylo",
                     "7a4xvbtt",
-                    "wgv4haro",
                 ],  # Smart Lock
                 [TuyaLockMotorStateMapping(dp_id=47)],
             ),

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -190,3 +190,52 @@ async def test_guard_dog_lock(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     device._send_datapoints.assert_called_with([DPCode.MANUAL_LOCK])
     assert device.datapoints[DPCode.MANUAL_LOCK].value is False
+
+    # Verify refined sensor mappings for wgv4haro
+    from custom_components.tuya_ble.sensor import (
+        get_mapping_by_device as get_sensor_mapping,
+    )
+
+    sensor_mappings = get_sensor_mapping(device)
+    assert any(
+        m.description.key == "unlock_fingerprint" and m.dp_id == 12
+        for m in sensor_mappings
+    )
+    assert any(
+        m.description.key == "unlock_password" and m.dp_id == 13
+        for m in sensor_mappings
+    )
+    assert any(
+        m.description.key == "unlock_dynamic" and m.dp_id == 14 for m in sensor_mappings
+    )
+    assert any(
+        m.description.key == "unlock_ble" and m.dp_id == 19 for m in sensor_mappings
+    )
+    assert any(
+        m.description.key == "unlock_temp_pwd" and m.dp_id == 55
+        for m in sensor_mappings
+    )
+    assert any(
+        m.description.key == "unlock_app" and m.dp_id == 62 for m in sensor_mappings
+    )
+
+    # Verify button mappings for wgv4haro
+    from custom_components.tuya_ble.button import (
+        get_mapping_by_device as get_button_mapping,
+    )
+
+    button_mappings = get_button_mapping(device)
+    assert any(
+        m.description.key == "bluetooth_unlock" and m.dp_id == 6
+        for m in button_mappings
+    )
+
+    # Verify select mappings for wgv4haro
+    from custom_components.tuya_ble.select import (
+        get_mapping_by_device as get_select_mapping,
+    )
+
+    select_mappings = get_select_mapping(device)
+    assert any(
+        m.description.key == "beep_volume" and m.dp_id == 31 for m in select_mappings
+    )

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -19,7 +19,7 @@ CONFIG = {
                 "id": "lock",
                 "platform": "lock",
                 "restore_on_reconnect": False,
-                "address": "12:23:44"
+                "address": "12:23:44",
             }
         ],
     }
@@ -30,7 +30,12 @@ async def test_lock(hass: HomeAssistant) -> None:
     from pytest_homeassistant_custom_component.common import MockConfigEntry
     from custom_components.tuya_ble.const import DOMAIN
     from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
-    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from custom_components.tuya_ble.devices import (
+        TuyaBLEDevice,
+        TuyaBLEProductInfo,
+        TuyaBLECoordinator,
+        TuyaBLEData,
+    )
     from bleak.backends.device import BLEDevice
 
     entry = MockConfigEntry(
@@ -64,9 +69,7 @@ async def test_lock(hass: HomeAssistant) -> None:
     )
     hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
 
-    entity = TuyaBLELock(
-        hass, coordinator, device, product_info
-    )
+    entity = TuyaBLELock(hass, coordinator, device, product_info)
     entity.async_write_ha_state = Mock()
 
     # Initial state
@@ -77,7 +80,102 @@ async def test_lock(hass: HomeAssistant) -> None:
     assert entity.is_locked is True
 
     # Update coordinator state to unlocked: "lock_motor_state" = True
-    device.datapoints._update_from_device(DPCode.LOCK_MOTOR_STATE, 0, 0, TuyaBLEDataPointType.DT_BOOL, True)
+    device.datapoints._update_from_device(
+        DPCode.LOCK_MOTOR_STATE, 0, 0, TuyaBLEDataPointType.DT_BOOL, True
+    )
+    entity._handle_coordinator_update()
+    assert entity.is_locked is False
+
+    # Call async_lock
+    await entity.async_lock()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_called_with([DPCode.MANUAL_LOCK])
+    assert device.datapoints[DPCode.MANUAL_LOCK].value is True
+
+    # Call async_unlock
+    await entity.async_unlock()
+    await hass.async_block_till_done()
+    device._send_datapoints.assert_called_with([DPCode.MANUAL_LOCK])
+    assert device.datapoints[DPCode.MANUAL_LOCK].value is False
+
+
+async def test_guard_dog_lock(hass: HomeAssistant) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import (
+        TuyaBLEDevice,
+        TuyaBLECoordinator,
+        TuyaBLEData,
+        get_device_product_info,
+    )
+    from custom_components.tuya_ble.tuya_ble.manager import TuyaBLEDeviceCredentials
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE Guard Dog",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+
+    # Set credentials with wgv4haro
+    device._device_info = TuyaBLEDeviceCredentials(
+        uuid="uuid123",
+        local_key="wV[NcWGUSFF`dSgO",
+        device_id="767823809c9c1f458745",
+        category="ms",
+        product_id="wgv4haro",
+        device_name="Guard Dog Lock",
+        product_model="BS_PLD01",
+        product_name="Guard Dog Security Smart Lock",
+        functions=[],
+        status_range=[],
+    )
+
+    # Mock _send_datapoints to prevent actual BLE calls and exceptions
+    device._send_datapoints = AsyncMock()
+
+    product_info = get_device_product_info(device)
+    assert product_info is not None
+    assert product_info.name == "Guard Dog Security Smart Lock"
+    assert product_info.manufacturer == "Guard Dog Security"
+    assert product_info.lock == 1
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    entity = TuyaBLELock(hass, coordinator, device, product_info)
+    entity.async_write_ha_state = Mock()
+
+    # Initial state
+    assert entity.available is False
+    coordinator._async_handle_connect()
+    assert entity.available is True
+    # Initial: not motor_state.value -> True (locked) because get_or_create defaults to False
+    assert entity.is_locked is True
+
+    # Update coordinator state to unlocked: "lock_motor_state" = True
+    device.datapoints._update_from_device(
+        DPCode.LOCK_MOTOR_STATE, 0, 0, TuyaBLEDataPointType.DT_BOOL, True
+    )
     entity._handle_coordinator_update()
     assert entity.is_locked is False
 


### PR DESCRIPTION
Adds support for Guard Dog Security BS_PLD01 smart lock with product ID wgv4haro. Links issue #251 via fix #251 in the commit.

---
*PR created automatically by Jules for task [1189957519969906491](https://jules.google.com/task/1189957519969906491) started by @CloCkWeRX*