### PR TITLE
feat(protocol): Add Tuya BLE v4 datapoint transport

### DIFF
--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -1237,13 +1237,23 @@ class TuyaBLEDevice:
         )
         return (timestamp, end_pos)
 
-    def _parse_datapoints_v3(
-        self, timestamp: float, flags: int, data: bytes, start_pos: int
+    def _parse_datapoints(
+        self,
+        timestamp: float,
+        flags: int,
+        data: bytes,
+        start_pos: int,
+        length_size: int,
     ) -> int:
+        """Parse Tuya KLV datapoints with the requested value-length width."""
+        if length_size not in (1, 2):
+            raise ValueError("Tuya KLV length width must be one or two bytes")
+
         datapoints: list[TuyaBLEDataPoint] = []
 
         pos = start_pos
-        while len(data) - pos >= 4:
+        header_size = 2 + length_size
+        while len(data) - pos >= header_size:
             id: int = data[pos]
             pos += 1
             _type: int = data[pos]
@@ -1251,8 +1261,8 @@ class TuyaBLEDevice:
                 raise TuyaBLEDataFormatError()
             type: TuyaBLEDataPointType = TuyaBLEDataPointType(_type)
             pos += 1
-            data_len: int = data[pos]
-            pos += 1
+            data_len = int.from_bytes(data[pos : pos + length_size], "big")
+            pos += length_size
             next_pos = pos + data_len
             if next_pos > len(data):
                 raise TuyaBLEDataLengthError()
@@ -1279,6 +1289,19 @@ class TuyaBLEDevice:
             pos = next_pos
 
         self._fire_callbacks(datapoints)
+        return pos
+
+    def _parse_datapoints_v3(
+        self, timestamp: float, flags: int, data: bytes, start_pos: int
+    ) -> int:
+        """Parse Tuya BLE protocol-v3 datapoints."""
+        return self._parse_datapoints(timestamp, flags, data, start_pos, 1)
+
+    def _parse_datapoints_v4(
+        self, timestamp: float, flags: int, data: bytes, start_pos: int
+    ) -> int:
+        """Parse Tuya BLE protocol-v4 datapoints."""
+        return self._parse_datapoints(timestamp, flags, data, start_pos, 2)
 
     def _handle_command_or_response(
         self, seq_num: int, response_to: int, code: TuyaBLECode, data: bytes
@@ -1318,6 +1341,11 @@ class TuyaBLEDevice:
                 if len(data) != 1:
                     raise TuyaBLEDataLengthError()
                 result = data[0]
+
+            case TuyaBLECode.FUN_SENDER_DPS_V4:
+                if len(data) != 6:
+                    raise TuyaBLEDataLengthError()
+                result = data[5]
 
             case TuyaBLECode.FUN_RECEIVE_TIME1_REQ:
                 if len(data) != 0:
@@ -1374,6 +1402,33 @@ class TuyaBLEDevice:
                 self._parse_datapoints_v3(time.time(), flags, data, pos)
                 data = pack(">HBB", dp_seq_num, flags, 0)
                 asyncio.create_task(self._send_response(code, data, seq_num))
+
+            case TuyaBLECode.FUN_RECEIVE_DP_V4:
+                if len(data) < 7:
+                    raise TuyaBLEDataLengthError()
+                if data[0] != 0:
+                    raise TuyaBLEDataFormatError()
+                send_flags = data[5]
+                mode = data[6]
+                self._parse_datapoints_v4(time.time(), mode, data, 7)
+                if (send_flags & 0x80) == 0:
+                    asyncio.create_task(
+                        self._send_response(code, data[:7] + b"\x00", seq_num)
+                    )
+
+            case TuyaBLECode.FUN_RECEIVE_TIME_DP_V4:
+                if len(data) < 8:
+                    raise TuyaBLEDataLengthError()
+                if data[0] != 0:
+                    raise TuyaBLEDataFormatError()
+                send_flags = data[5]
+                mode = data[6]
+                timestamp, pos = self._parse_timestamp(data, 7)
+                self._parse_datapoints_v4(timestamp, mode, data, pos)
+                if (send_flags & 0x80) == 0:
+                    asyncio.create_task(
+                        self._send_response(code, data[:7] + b"\x00", seq_num)
+                    )
 
         if response_to != 0:
             future = self._input_expected_responses.pop(response_to, None)
@@ -1523,8 +1578,11 @@ class TuyaBLEDevice:
                 self._clean_input()
                 return
 
-    async def _send_datapoints_v3(self, datapoint_ids: list[int]) -> None:
-        """Send new values of datapoints to the device."""
+    def _encode_datapoints(self, datapoint_ids: list[int], length_size: int) -> bytes:
+        """Encode datapoints with the requested Tuya KLV value-length width."""
+        if length_size not in (1, 2):
+            raise ValueError("Tuya KLV length width must be one or two bytes")
+
         data = bytearray()
         for dp_id in datapoint_ids:
             dp = self._datapoints[dp_id]
@@ -1536,21 +1594,37 @@ class TuyaBLEDevice:
                 dp.type.name,
                 dp.value,
             )
-            data += pack(">BBB", dp.id, int(dp.type.value), len(value))
+            if length_size == 1:
+                data += pack(">BBB", dp.id, int(dp.type.value), len(value))
+            else:
+                data += pack(">BBH", dp.id, int(dp.type.value), len(value))
             data += value
 
+        return bytes(data)
+
+    async def _send_datapoints_v3(self, datapoint_ids: list[int]) -> None:
+        """Send new values using the protocol-v3 DP command."""
+        data = self._encode_datapoints(datapoint_ids, 1)
         await self._send_packet(TuyaBLECode.FUN_SENDER_DPS, data)
+
+    async def _send_datapoints_v4(self, datapoint_ids: list[int]) -> None:
+        """Send new values using the protocol-v4 DP command."""
+        dp_seq_num = await self._get_seq_num()
+        data = pack(">BI", 0, dp_seq_num)
+        data += self._encode_datapoints(datapoint_ids, 2)
+        await self._send_packet(TuyaBLECode.FUN_SENDER_DPS_V4, data)
 
     async def _send_datapoints(self, datapoint_ids: list[int]) -> None:
         """Send new values of datapoints to the device."""
         if self._protocol_version == 3:
             await self._send_datapoints_v3(datapoint_ids)
+        elif self._protocol_version >= 4:
+            await self._send_datapoints_v4(datapoint_ids)
         else:
             raise TuyaBLEDeviceError(0)
 
     async def set_multiple_values(self, dp_updates: dict[int, Any]) -> None:
         """Set multiple datapoint values in a single atomic BLE payload."""
-        data = bytearray()
         updated_dps = []
         for dp_id, value in dp_updates.items():
             dp = self._datapoints[dp_id]
@@ -1571,12 +1645,7 @@ class TuyaBLEDevice:
             dp._changed_by_device = False
             updated_dps.append(dp)
 
-            # Build the payload according to protocol version 3
-            val_bytes = dp._get_value()
-            data += pack(">BBB", dp.id, int(dp.type.value), len(val_bytes))
-            data += val_bytes
-
-        if not data:
+        if not updated_dps:
             return
-        await self._send_packet(TuyaBLECode.FUN_SENDER_DPS, data)
+        await self._send_datapoints([dp.id for dp in updated_dps])
         self._fire_callbacks(updated_dps)

--- a/tests/test_protocol_v4.py
+++ b/tests/test_protocol_v4.py
@@ -1,0 +1,152 @@
+"""Tests for Tuya BLE protocol-v4 datapoint transport."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+from bleak.backends.device import BLEDevice
+import pytest
+
+from custom_components.tuya_ble.tuya_ble import (
+    TuyaBLEDataPointType,
+    TuyaBLEDevice,
+)
+from custom_components.tuya_ble.tuya_ble.const import TuyaBLECode
+from custom_components.tuya_ble.tuya_ble.exceptions import TuyaBLEDeviceError
+
+
+def _make_device() -> TuyaBLEDevice:
+    ble_device = BLEDevice(
+        name="protocol-v4-test",
+        address="11:22:33:44:55:66",
+        details="",
+        rssi=-50,
+    )
+    return TuyaBLEDevice(Mock(), ble_device)
+
+
+async def test_protocol_v4_write_uses_two_byte_datapoint_length() -> None:
+    """Protocol v4 writes use command 0x0027 and a four-byte DP sequence."""
+    device = _make_device()
+    device._protocol_version = 4
+    datapoint = device.datapoints.get_or_create(
+        105, TuyaBLEDataPointType.DT_BOOL, False
+    )
+    datapoint._value = True
+    device._get_seq_num = AsyncMock(return_value=0x01020304)
+    device._send_packet = AsyncMock()
+
+    await device._send_datapoints([105])
+
+    device._send_packet.assert_awaited_once_with(
+        TuyaBLECode.FUN_SENDER_DPS_V4,
+        bytes.fromhex("00 01020304 69 01 0001 01"),
+    )
+
+
+async def test_protocol_v3_write_keeps_one_byte_datapoint_length() -> None:
+    """The shared encoder preserves the existing protocol-v3 wire format."""
+    device = _make_device()
+    device._protocol_version = 3
+    datapoint = device.datapoints.get_or_create(
+        105, TuyaBLEDataPointType.DT_BOOL, False
+    )
+    datapoint._value = True
+    device._send_packet = AsyncMock()
+
+    await device._send_datapoints([105])
+
+    device._send_packet.assert_awaited_once_with(
+        TuyaBLECode.FUN_SENDER_DPS,
+        bytes.fromhex("69 01 01 01"),
+    )
+
+
+async def test_protocol_v4_atomic_write_uses_v4_encoder() -> None:
+    """Atomic writes dispatch through the protocol-specific encoder."""
+    device = _make_device()
+    device._protocol_version = 4
+    device.datapoints.get_or_create(105, TuyaBLEDataPointType.DT_BOOL, False)
+    device.datapoints.get_or_create(106, TuyaBLEDataPointType.DT_VALUE, 0)
+    device._get_seq_num = AsyncMock(return_value=0x01020304)
+    device._send_packet = AsyncMock()
+
+    await device.set_multiple_values({105: True, 106: 60})
+
+    device._send_packet.assert_awaited_once_with(
+        TuyaBLECode.FUN_SENDER_DPS_V4,
+        bytes.fromhex("00 01020304 69 01 0001 01 6a 02 0004 0000003c"),
+    )
+
+
+async def test_protocol_v4_report_updates_datapoint_and_is_acknowledged() -> None:
+    """Command 0x8006 reports a v4 datapoint and receives a metadata echo."""
+    device = _make_device()
+    device._send_response = AsyncMock()
+    report = bytes.fromhex("00 01020304 00 00 0b 02 0004 00000057")
+
+    device._handle_command_or_response(23, 0, TuyaBLECode.FUN_RECEIVE_DP_V4, report)
+    await asyncio.sleep(0)
+
+    datapoint = device.datapoints[11]
+    assert datapoint is not None
+    assert datapoint.type == TuyaBLEDataPointType.DT_VALUE
+    assert datapoint.value == 87
+    assert datapoint.flags == 0
+    device._send_response.assert_awaited_once_with(
+        TuyaBLECode.FUN_RECEIVE_DP_V4,
+        bytes.fromhex("00 01020304 00 00 00"),
+        23,
+    )
+
+
+async def test_protocol_v4_report_honors_no_ack_flag() -> None:
+    """Bit 7 in the v4 send flags suppresses the acknowledgement."""
+    device = _make_device()
+    device._send_response = AsyncMock()
+    report = bytes.fromhex("00 01020304 80 00 0b 02 0004 00000057")
+
+    device._handle_command_or_response(23, 0, TuyaBLECode.FUN_RECEIVE_DP_V4, report)
+    await asyncio.sleep(0)
+
+    assert device.datapoints[11].value == 87
+    device._send_response.assert_not_awaited()
+
+
+async def test_protocol_v4_timestamped_report() -> None:
+    """Command 0x8007 carries a timestamp before its v4 datapoints."""
+    device = _make_device()
+    device._send_response = AsyncMock()
+    report = bytes.fromhex("00 01020304 00 04 01 66aabbcc 0b 02 0004 00000062")
+
+    device._handle_command_or_response(
+        24, 0, TuyaBLECode.FUN_RECEIVE_TIME_DP_V4, report
+    )
+    await asyncio.sleep(0)
+
+    datapoint = device.datapoints[11]
+    assert datapoint is not None
+    assert datapoint.value == 98
+    assert datapoint.flags == 4
+    assert datapoint.timestamp == 0x66AABBCC
+    device._send_response.assert_awaited_once_with(
+        TuyaBLECode.FUN_RECEIVE_TIME_DP_V4,
+        bytes.fromhex("00 01020304 00 04 00"),
+        24,
+    )
+
+
+async def test_protocol_v4_write_response_propagates_device_error() -> None:
+    """The final byte of a 0x0027 response is its result code."""
+    device = _make_device()
+    response = asyncio.get_running_loop().create_future()
+    device._input_expected_responses[9] = response
+
+    device._handle_command_or_response(
+        25,
+        9,
+        TuyaBLECode.FUN_SENDER_DPS_V4,
+        bytes.fromhex("00 01020304 02"),
+    )
+
+    with pytest.raises(TuyaBLEDeviceError):
+        await response


### PR DESCRIPTION
## Summary

- encode protocol-v4 writes with command 0x0027, a payload version byte, and a 4-byte datapoint sequence
- parse 0x8006 data reports and 0x8007 timestamped reports with 2-byte datapoint lengths
- acknowledge reports unless the no-ack flag is set, and propagate device-side write errors
- preserve the protocol-v3 wire format and route atomic multi-value writes through the protocol-specific encoder

## Protocol reference

The report handling follows the official [Tuya Bluetooth LE local log protocol](https://developer.tuya.com/en/docs/iot-device-dev/Local-log-BLE?_source=github&id=Kam0xlcc837f2).

## Validation

- 29 tests pass on this standalone branch
- the combined three-PR series passes all 40 tests
- Black, codespell, JSON parsing, and git diff --check pass
- packet-level tests cover exact v3/v4 bytes, 0x8006/0x8007, ack/no-ack behavior, timestamps, atomic writes, and result errors
- the combined implementation was validated live on a YZD02B: each valve completed a one-minute cycle, each usage counter reported 60 seconds, battery reported 98%, and Home Assistant logged no Tuya BLE errors

## Series

1. This PR: generic v4 transport
2. #255: SecKey authentication and security levels 14/15
3. #256: YZD02B mapping and product-scoped handshake