### PR TITLE
feat(security): Support Tuya BLE SecKey authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ After adding to Home Assistant integration should discover all supported Bluetoo
 
 The integration works locally, but connection to Tuya BLE device requires device ID and encryption key from Tuya IOT cloud. It could be obtained using the same credentials as in the previous official Tuya integration. To obtain the credentials, please refer to official Tuya integration [documentation](https://web.archive.org/web/20231228044831/https://www.home-assistant.io/integrations/tuya/) [[1]](https://github.com/home-assistant/home-assistant.io/blob/a4e6d4819f1db584cc66ba2082508d3978f83f7e/source/_integrations/tuya.markdown)
 
+Newer protocol-v2 devices may also require a 16-character `secKey`. Enter it in
+the optional **Tuya BLE SecKey** field when configuring such a device.
+
 ## Supported devices list
 
 <table>

--- a/custom_components/tuya_ble/cloud.py
+++ b/custom_components/tuya_ble/cloud.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_PRODUCT_MODEL,
     CONF_UUID,
     CONF_LOCAL_KEY,
+    CONF_SEC_KEY,
     CONF_CATEGORY,
     CONF_PRODUCT_ID,
     CONF_DEVICE_NAME,
@@ -204,6 +205,9 @@ class HASSTuyaBLEDeviceManager(AbstaractTuyaBLEDeviceManager):
                                 CONF_PRODUCT_MODEL: device.get("model"),
                                 CONF_PRODUCT_NAME: device.get("product_name"),
                             }
+                            sec_key = device.get("sec_key") or device.get("secKey")
+                            if sec_key:
+                                item.credentials[mac][CONF_SEC_KEY] = sec_key
 
                             spec_response = await self._hass.async_add_executor_job(
                                 item.api.get,
@@ -306,6 +310,7 @@ class HASSTuyaBLEDeviceManager(AbstaractTuyaBLEDeviceManager):
                 credentials = item.credentials.get(address)
 
         if credentials:
+            sec_key = credentials.get(CONF_SEC_KEY) or self._data.get(CONF_SEC_KEY)
             result = TuyaBLEDeviceCredentials(
                 credentials.get(CONF_UUID, ""),
                 credentials.get(CONF_LOCAL_KEY, ""),
@@ -317,12 +322,15 @@ class HASSTuyaBLEDeviceManager(AbstaractTuyaBLEDeviceManager):
                 credentials.get(CONF_PRODUCT_NAME, ""),
                 credentials.get(CONF_FUNCTIONS, []),
                 credentials.get(CONF_STATUS_RANGE, []),
+                sec_key=sec_key,
             )
             _LOGGER.debug("Retrieved: %s", result)
             if save_data:
                 if item:
                     self._data.update(item.login)
                 self._data.update(credentials)
+                if sec_key:
+                    self._data[CONF_SEC_KEY] = sec_key
 
         return result
 

--- a/custom_components/tuya_ble/config_flow.py
+++ b/custom_components/tuya_ble/config_flow.py
@@ -26,6 +26,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowHandler, FlowResult
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from .tuya_ble import SERVICE_UUIDS, TuyaBLEDeviceCredentials
 
@@ -41,6 +46,7 @@ from .const import (
     CONF_APP_TYPE,
     CONF_AUTH_TYPE,
     CONF_ENDPOINT,
+    CONF_SEC_KEY,
     DOMAIN,
 )
 from .devices import TuyaBLEData, get_device_readable_name
@@ -73,6 +79,8 @@ async def _try_login(
         CONF_PASSWORD: user_input[CONF_PASSWORD],
         CONF_COUNTRY_CODE: country.country_code,
     }
+    if sec_key := user_input.get(CONF_SEC_KEY):
+        data[CONF_SEC_KEY] = sec_key
 
     for app_type in (TUYA_SMART_APP, SMARTLIFE_APP, ""):
         data[CONF_APP_TYPE] = app_type
@@ -139,6 +147,10 @@ def _show_login_form(
                     CONF_ACCESS_SECRET,
                     default=user_input.get(CONF_ACCESS_SECRET, ""),
                 ): str,
+                vol.Optional(
+                    CONF_SEC_KEY,
+                    default=user_input.get(CONF_SEC_KEY, ""),
+                ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
                 vol.Required(
                     CONF_USERNAME, default=user_input.get(CONF_USERNAME, "")
                 ): str,
@@ -187,6 +199,8 @@ class TuyaBLEOptionsFlow(OptionsFlowWithConfigEntry):
                     placeholders,
                 )
                 if login_data:
+                    entry.manager.data.pop(CONF_SEC_KEY, None)
+                    entry.manager.data.update(login_data)
                     credentials = await entry.manager.get_device_credentials(
                         address, True, True
                     )

--- a/custom_components/tuya_ble/const.py
+++ b/custom_components/tuya_ble/const.py
@@ -17,6 +17,7 @@ SET_DISCONNECTED_DELAY = 10 * 60
 
 CONF_UUID: Final = "uuid"
 CONF_LOCAL_KEY: Final = "local_key"
+CONF_SEC_KEY: Final = "sec_key"
 CONF_CATEGORY: Final = "category"
 CONF_PRODUCT_ID: Final = "product_id"
 CONF_DEVICE_NAME: Final = "device_name"

--- a/custom_components/tuya_ble/diagnostics.py
+++ b/custom_components/tuya_ble/diagnostics.py
@@ -5,7 +5,9 @@ from homeassistant.components.diagnostics import async_redact_data
 TO_REDACT = {
     "username",
     "password",
+    "access_secret",
     "local_key",
+    "sec_key",
     "api_key",
     "token",
     "host",

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -20,6 +20,7 @@
                 "data": {
                     "access_id": "Tuya IoT Access ID",
                     "access_secret": "Tuya IoT Access Secret",
+                    "sec_key": "Tuya BLE SecKey (optional)",
                     "country_code": "Country",
                     "password": "Password",
                     "username": "Account"

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -20,6 +20,7 @@
                 "data": {
                     "access_id": "Tuya IoT Access ID",
                     "access_secret": "Tuya IoT Access Secret",
+                    "sec_key": "Tuya BLE SecKey (optional)",
                     "country_code": "Country",
                     "password": "Password",
                     "username": "Account"

--- a/custom_components/tuya_ble/tuya_ble/manager.py
+++ b/custom_components/tuya_ble/tuya_ble/manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 
@@ -10,7 +10,7 @@ class TuyaBLEDeviceCredentials:
     """Model of credentials"""
 
     uuid: str
-    local_key: str
+    local_key: str = field(repr=False)
     device_id: str
     category: str
     product_id: str
@@ -19,11 +19,13 @@ class TuyaBLEDeviceCredentials:
     product_name: str | None
     functions: List | None
     status_range: List | None
+    sec_key: str | None = field(default=None, repr=False)
 
     def __str__(self):
         return (
             "uuid: %s, "
             "local_key: %s, "
+            "sec_key: %s, "
             "device_id: %s, "
             "category: %s, "
             "product_id: %s, "
@@ -34,7 +36,8 @@ class TuyaBLEDeviceCredentials:
             "status_range: %s"
         ) % (
             self.uuid,
-            f'{"x" * 10}{self.local_key[10:]}',  # Mask the majority of the local key
+            "**REDACTED**",
+            "**REDACTED**" if self.sec_key else None,
             self.device_id,
             self.category,
             self.product_id,
@@ -72,6 +75,7 @@ class AbstaractTuyaBLEDeviceManager(ABC):
         product_name: str | None,
         functions: List | None,
         status_range: List | None,
+        sec_key: str | None = None,
     ) -> TuyaBLEDeviceCredentials | None:
         """Checks and creates credentials of the Tuya BLE device."""
         if uuid and local_key and device_id and category and product_id:
@@ -86,6 +90,7 @@ class AbstaractTuyaBLEDeviceManager(ABC):
                 product_name,
                 functions,
                 status_range,
+                sec_key,
             )
 
         return None

--- a/custom_components/tuya_ble/tuya_ble/security.py
+++ b/custom_components/tuya_ble/tuya_ble/security.py
@@ -1,0 +1,68 @@
+"""Tuya BLE login and session key derivation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+
+
+@dataclass(frozen=True, slots=True)
+class TuyaBLESecurityMaterial:
+    """Derive the keys and security flags used by a Tuya BLE device."""
+
+    local_key: str = field(repr=False)
+    sec_key: str | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        try:
+            local_key = self.local_key.encode("ascii")
+            sec_key = self.sec_key.encode("ascii") if self.sec_key else None
+        except UnicodeEncodeError as err:
+            raise ValueError(
+                "Tuya BLE keys must contain only ASCII characters"
+            ) from err
+
+        if len(local_key) < 6:
+            raise ValueError("Tuya BLE local_key must contain at least 6 bytes")
+        if sec_key and len(sec_key) != 16:
+            raise ValueError("Tuya BLE sec_key must contain exactly 16 bytes")
+
+    @property
+    def protocol_v2(self) -> bool:
+        """Return whether protocol-v2 key derivation is enabled."""
+        return bool(self.sec_key)
+
+    @property
+    def pairing_login_key(self) -> bytes:
+        """Return the six-byte login key carried by the pair request."""
+        return self.local_key.encode("ascii")[:6]
+
+    @property
+    def _derivation_material(self) -> bytes:
+        if self.protocol_v2:
+            return f"{self.local_key}{self.sec_key}".encode("ascii")
+        return self.pairing_login_key
+
+    @property
+    def login_key(self) -> bytes:
+        """Return the AES key used for the device-info exchange."""
+        return hashlib.md5(self._derivation_material, usedforsecurity=False).digest()
+
+    def session_key(self, device_random: bytes) -> bytes:
+        """Return the AES key used after the device-info exchange."""
+        if len(device_random) != 6:
+            raise ValueError("Tuya BLE device random must contain exactly 6 bytes")
+        return hashlib.md5(
+            self._derivation_material + device_random,
+            usedforsecurity=False,
+        ).digest()
+
+    @property
+    def login_flag(self) -> int:
+        """Return the Tuya security level for device-info packets."""
+        return 14 if self.protocol_v2 else 4
+
+    @property
+    def session_flag(self) -> int:
+        """Return the Tuya security level for authenticated packets."""
+        return 15 if self.protocol_v2 else 5

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -52,6 +52,7 @@ from .exceptions import (
     TuyaBLEEnumValueError,
 )
 from .manager import AbstaractTuyaBLEDeviceManager, TuyaBLEDeviceCredentials
+from .security import TuyaBLESecurityMaterial
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -311,6 +312,7 @@ class TuyaBLEDevice:
         self._local_key: bytes | None = None
         self._login_key: bytes | None = None
         self._session_key: bytes | None = None
+        self._security_material: TuyaBLESecurityMaterial | None = None
 
         self._is_paired = False
 
@@ -369,8 +371,12 @@ class TuyaBLEDevice:
                     self._ble_device.address, False
                 )
             if self._device_info:
-                self._local_key = self._device_info.local_key[:6].encode()
-                self._login_key = hashlib.md5(self._local_key).digest()
+                self._security_material = TuyaBLESecurityMaterial(
+                    self._device_info.local_key,
+                    self._device_info.sec_key,
+                )
+                self._local_key = self._security_material.pairing_login_key
+                self._login_key = self._security_material.login_key
 
                 self.append_functions(
                     self._device_info.functions, self._device_info.status_range
@@ -964,10 +970,10 @@ class TuyaBLEDevice:
         security_flag: bytes
         if code == TuyaBLECode.FUN_SENDER_DEVICE_INFO:
             key = self._login_key
-            security_flag = b"\x04"
+            security_flag = pack(">B", self._security_material.login_flag)
         else:
             key = self._session_key
-            security_flag = b"\x05"
+            security_flag = pack(">B", self._security_material.session_flag)
 
         raw = bytearray()
         raw += pack(">IIHH", seq_num, response_to, code.value, len(data))
@@ -1205,6 +1211,10 @@ class TuyaBLEDevice:
             return self._login_key
         if security_flag == 5:
             return self._session_key
+        if security_flag == 14:
+            return self._login_key
+        if security_flag == 15:
+            return self._session_key
 
     def _parse_timestamp(self, data: bytes, start_pos: int) -> tuple(float, int):
         timestamp: float
@@ -1299,7 +1309,7 @@ class TuyaBLEDevice:
                 self._is_bound = data[5] != 0
 
                 srand = data[6:12]
-                self._session_key = hashlib.md5(self._local_key + srand).digest()
+                self._session_key = self._security_material.session_key(srand)
                 self._auth_key = data[14:46]
 
             case TuyaBLECode.FUN_SENDER_PAIR:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,210 @@
+"""Tests for Tuya BLE classic and protocol-v2 security."""
+
+from unittest.mock import AsyncMock, Mock
+
+from bleak.backends.device import BLEDevice
+from homeassistant.const import (
+    CONF_COUNTRY_CODE,
+    CONF_DEVICE_ID,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+from homeassistant.core import HomeAssistant
+import pytest
+
+from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+from custom_components.tuya_ble.config_flow import _try_login
+from custom_components.tuya_ble.const import (
+    CONF_ACCESS_ID,
+    CONF_ACCESS_SECRET,
+    CONF_CATEGORY,
+    CONF_DEVICE_NAME,
+    CONF_LOCAL_KEY,
+    CONF_PRODUCT_ID,
+    CONF_PRODUCT_MODEL,
+    CONF_PRODUCT_NAME,
+    CONF_SEC_KEY,
+    CONF_UUID,
+    TUYA_COUNTRIES,
+)
+from custom_components.tuya_ble.diagnostics import TO_REDACT
+from custom_components.tuya_ble.tuya_ble import (
+    TuyaBLEDevice,
+    TuyaBLEDeviceCredentials,
+)
+from custom_components.tuya_ble.tuya_ble.const import TuyaBLECode
+from custom_components.tuya_ble.tuya_ble.security import TuyaBLESecurityMaterial
+
+
+LOCAL_KEY = "0123456789abcdef"
+SEC_KEY = "fedcba9876543210"
+DEVICE_RANDOM = bytes.fromhex("010203040506")
+
+
+def _make_device() -> TuyaBLEDevice:
+    ble_device = BLEDevice(
+        name="security-test",
+        address="11:22:33:44:55:66",
+        details="",
+        rssi=-50,
+    )
+    return TuyaBLEDevice(Mock(), ble_device)
+
+
+def test_protocol_v2_security_material() -> None:
+    """A SecKey enables protocol-v2 derivation and security levels 14/15."""
+    material = TuyaBLESecurityMaterial(LOCAL_KEY, SEC_KEY)
+
+    assert material.protocol_v2
+    assert material.login_flag == 14
+    assert material.session_flag == 15
+    assert material.pairing_login_key == b"012345"
+    assert material.login_key.hex() == "957b49743a06a938c9246950faadbaa9"
+    assert (
+        material.session_key(DEVICE_RANDOM).hex() == "316fa9b0eab1ca83b7ffff2e97379659"
+    )
+
+
+def test_classic_security_material() -> None:
+    """Devices without a SecKey keep the classic derivation and levels 4/5."""
+    material = TuyaBLESecurityMaterial(LOCAL_KEY)
+
+    assert not material.protocol_v2
+    assert material.login_flag == 4
+    assert material.session_flag == 5
+    assert material.pairing_login_key == b"012345"
+    assert material.login_key.hex() == "d6a9a933c8aafc51e55ac0662b6e4d4a"
+    assert (
+        material.session_key(DEVICE_RANDOM).hex() == "a776a41c02fd75d3831a926549482d93"
+    )
+
+
+@pytest.mark.parametrize(
+    ("local_key", "sec_key"),
+    (
+        ("short", None),
+        (LOCAL_KEY, "too-short"),
+        ("clé-non-ascii", None),
+    ),
+)
+def test_security_material_validates_key_lengths_and_encoding(
+    local_key: str, sec_key: str | None
+) -> None:
+    """Invalid key material is rejected instead of silently downgrading."""
+    with pytest.raises(ValueError):
+        TuyaBLESecurityMaterial(local_key, sec_key)
+
+
+def test_protocol_v2_packets_use_security_levels_14_and_15() -> None:
+    """Outgoing and incoming packet key selection supports levels 14/15."""
+    device = _make_device()
+    material = TuyaBLESecurityMaterial(LOCAL_KEY, SEC_KEY)
+    device._security_material = material
+    device._login_key = material.login_key
+    device._session_key = material.session_key(DEVICE_RANDOM)
+    device._protocol_version = 2
+
+    login_packets = device._build_packets(
+        1, TuyaBLECode.FUN_SENDER_DEVICE_INFO, bytes()
+    )
+    session_packets = device._build_packets(
+        2, TuyaBLECode.FUN_SENDER_DEVICE_STATUS, bytes()
+    )
+
+    assert login_packets[0][3] == 14
+    assert session_packets[0][3] == 15
+    assert device._get_key(14) == device._login_key
+    assert device._get_key(15) == device._session_key
+
+
+def test_device_info_uses_protocol_v2_session_derivation() -> None:
+    """The device random is combined with both stored keys for the session."""
+    device = _make_device()
+    material = TuyaBLESecurityMaterial(LOCAL_KEY, SEC_KEY)
+    device._security_material = material
+    response = bytearray(46)
+    response[6:12] = DEVICE_RANDOM
+
+    device._handle_command_or_response(
+        3, 0, TuyaBLECode.FUN_SENDER_DEVICE_INFO, response
+    )
+
+    assert device._session_key == material.session_key(DEVICE_RANDOM)
+
+
+async def test_sec_key_is_loaded_from_saved_device_options(
+    hass: HomeAssistant,
+) -> None:
+    """The optional device SecKey reaches the runtime credentials object."""
+    data = {
+        CONF_UUID: "1234567890abcdef",
+        CONF_LOCAL_KEY: LOCAL_KEY,
+        CONF_SEC_KEY: SEC_KEY,
+        CONF_DEVICE_ID: "12345678901234567890",
+        CONF_CATEGORY: "test",
+        CONF_PRODUCT_ID: "test-product",
+        CONF_DEVICE_NAME: "Security test",
+        CONF_PRODUCT_MODEL: "TEST",
+        CONF_PRODUCT_NAME: "Security test",
+    }
+    manager = HASSTuyaBLEDeviceManager(hass, data)
+
+    credentials = await manager.get_device_credentials("11:22:33:44:55:66")
+
+    assert credentials is not None
+    assert credentials.sec_key == SEC_KEY
+
+
+async def test_login_flow_preserves_optional_sec_key() -> None:
+    """The password-style config field is persisted with device options."""
+    manager = Mock(spec=HASSTuyaBLEDeviceManager)
+    manager._login = AsyncMock(return_value={"success": True})
+    errors = {}
+    placeholders = {}
+    country = TUYA_COUNTRIES[0]
+
+    data = await _try_login(
+        manager,
+        {
+            CONF_COUNTRY_CODE: country.name,
+            CONF_ACCESS_ID: "test-access-id",
+            CONF_ACCESS_SECRET: "test-access-secret",
+            CONF_USERNAME: "test@example.com",
+            CONF_PASSWORD: "test-password",
+            CONF_SEC_KEY: SEC_KEY,
+        },
+        errors,
+        placeholders,
+    )
+
+    assert data is not None
+    assert data[CONF_SEC_KEY] == SEC_KEY
+    assert not errors
+
+
+def test_credentials_and_diagnostics_redact_both_keys() -> None:
+    """Neither credential rendering nor diagnostics expose key material."""
+    credentials = TuyaBLEDeviceCredentials(
+        uuid="1234567890abcdef",
+        local_key=LOCAL_KEY,
+        device_id="12345678901234567890",
+        category="test",
+        product_id="test-product",
+        device_name="Security test",
+        product_model="TEST",
+        product_name="Security test",
+        functions=[],
+        status_range=[],
+        sec_key=SEC_KEY,
+    )
+
+    for rendered in (str(credentials), repr(credentials)):
+        assert LOCAL_KEY not in rendered
+        assert SEC_KEY not in rendered
+    material = TuyaBLESecurityMaterial(LOCAL_KEY, SEC_KEY)
+    for rendered in (str(material), repr(material)):
+        assert LOCAL_KEY not in rendered
+        assert SEC_KEY not in rendered
+    assert CONF_LOCAL_KEY in TO_REDACT
+    assert CONF_SEC_KEY in TO_REDACT
+    assert CONF_ACCESS_SECRET in TO_REDACT


### PR DESCRIPTION
## Summary

- add an optional password-style SecKey field to config flow and entry persistence
- derive classic and protocol-v2 authentication material without changing the existing no-SecKey path
- support incoming and outgoing security levels 14/15 while preserving classic levels 4/5
- redact local_key, sec_key, and access_secret from string representations and diagnostics

## Protocol reference

Tuya documents activation material containing devID, secKey, and localKey in its official [Bluetooth LE and X-TuyaOS protocol](https://developer.tuya.com/en/docs/iot-device-dev/bluetooth_software_map_bt_ble_x?id=Kcydnl0bdaqzc).

## Validation

- 32 tests pass on this standalone branch
- the combined three-PR series passes all 40 tests
- Black, codespell, JSON parsing, and git diff --check pass
- deterministic tests cover exact classic/v2 MD5 vectors, packet security flags, session derivation, config flow persistence, runtime propagation, and secret redaction
- omitting SecKey preserves the exact classic key derivation and levels 4/5 behavior
- the combined implementation was validated live on a protocol-v2 YZD02B

## Series

1. #254: generic v4 transport
2. This PR: SecKey authentication and security levels 14/15
3. #256: YZD02B mapping and product-scoped handshake