### PR TITLE
fix(device): Support YZD02B irrigation timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ The integration works locally, but connection to Tuya BLE device requires device
     </tr>
     <tr>
       <td>2-outlet irrigation computer</td>
-      <td><code>hfgdqhho</code>, <code>fnlw6npo</code>, <code>qycalacn</code>, <code>jjqi2syk</code></td>
-      <td>Also known as: SGW02, SGW08, MOES BWV-YC02-EU-GY, Kogan SmarterHome KASMWATMRDA / KASMWTV2LVA.</td>
+      <td><code>hfgdqhho</code>, <code>fnlw6npo</code>, <code>qycalacn</code>, <code>jjqi2syk</code>, <code>jntxv3q4</code></td>
+      <td>Also known as: SGW02, SGW08, YZD02B, MOES BWV-YC02-EU-GY, Kogan SmarterHome KASMWATMRDA / KASMWTV2LVA.</td>
     </tr>
     <tr>
       <td>RESTMO BT Water Meter (FML026A)</td>

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -654,12 +654,15 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
     ),
     "ggq": TuyaBLECategoryInfo(
         products={
+            "jntxv3q4": TuyaBLEProductInfo(
+                name="YZD02B dual irrigation timer",
+            ),
             **dict.fromkeys(
                 ["6pahkcau", "hfgdqhho"],  # PPB A1  # SGW08  # device product_id
                 TuyaBLEProductInfo(
                     name="Irrigation computer",
                 ),
-            )
+            ),
         },
     ),
     "dd": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -653,6 +653,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     "qycalacn",
                     "fnlw6npo",
                     "jjqi2syk",
+                    "jntxv3q4",
                 ],  # Irrigation computer - dual outlet
                 [
                     TuyaBLENumberMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1307,6 +1307,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     "qycalacn",
                     "fnlw6npo",
                     "jjqi2syk",
+                    "jntxv3q4",
                 ],  # Irrigation computer - dual outlet
                 [
                     TuyaBLEBatteryMapping(dp_id=11),

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -626,6 +626,7 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     "qycalacn",
                     "fnlw6npo",
                     "jjqi2syk",
+                    "jntxv3q4",
                 ],  # Irrigation computer - dual outlet
                 [
                     TuyaBLESwitchMapping(

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -28,6 +28,7 @@ from Crypto.Cipher import AES
 
 from .const import (
     CHARACTERISTIC_NOTIFY,
+    CHARACTERISTIC_NOTIFY_FD50,
     CHARACTERISTIC_WRITE,
     GATT_MTU,
     MANUFACTURER_DATA_ID,
@@ -58,6 +59,9 @@ _LOGGER = logging.getLogger(__name__)
 
 
 BLEAK_EXCEPTIONS = (*BLEAK_RETRY_EXCEPTIONS, OSError)
+
+
+FD50_DEVICE_INFO_PRODUCT_IDS = frozenset({"jntxv3q4"})
 
 
 # @dataclass
@@ -336,6 +340,13 @@ class TuyaBLEDevice:
         _LOGGER.debug("%s: Initializing", self.address)
         if await self._update_device_info():
             self._decode_advertisement_data()
+
+    def _requires_fd50_device_info_handshake(self) -> bool:
+        """Return whether this device needs the TuyaOS FD50 login framing."""
+        return (
+            self._characteristic_notify == CHARACTERISTIC_NOTIFY_FD50
+            and self.product_id in FD50_DEVICE_INFO_PRODUCT_IDS
+        )
 
     def _build_pairing_request(self) -> bytes:
         result = bytearray()
@@ -782,8 +793,15 @@ class TuyaBLEDevice:
                             self._characteristic_write = write_uuid
                             break
                     try:
+                        notify_kwargs = (
+                            {"bluez": {"use_start_notify": True}}
+                            if self._requires_fd50_device_info_handshake()
+                            else {}
+                        )
                         await self._client.start_notify(
-                            self._characteristic_notify, self._notification_handler
+                            self._characteristic_notify,
+                            self._notification_handler,
+                            **notify_kwargs,
                         )
                     except Exception as ex:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
                         if "Bluetooth is already shutdown" in str(ex):
@@ -807,7 +825,11 @@ class TuyaBLEDevice:
                     try:
                         if not await self._send_packet_while_connected(
                             TuyaBLECode.FUN_SENDER_DEVICE_INFO,
-                            bytes(0),
+                            (
+                                b"\x00\xf3"
+                                if self._requires_fd50_device_info_handshake()
+                                else bytes(0)
+                            ),
                             0,
                             True,
                         ):
@@ -962,6 +984,10 @@ class TuyaBLEDevice:
         key: bytes
         iv = secrets.token_bytes(16)
         security_flag: bytes
+        fd50_device_info = (
+            code == TuyaBLECode.FUN_SENDER_DEVICE_INFO
+            and self._requires_fd50_device_info_handshake()
+        )
         if code == TuyaBLECode.FUN_SENDER_DEVICE_INFO:
             key = self._login_key
             security_flag = b"\x04"
@@ -990,7 +1016,10 @@ class TuyaBLEDevice:
 
             if packet_num == 0:
                 packet += self._pack_int(length)
-                packet += pack(">B", self._protocol_version << 4)
+                packet_protocol_version = (
+                    2 if fd50_device_info else self._protocol_version
+                )
+                packet += pack(">B", packet_protocol_version << 4)
 
             data_part = encrypted[
                 pos:pos + GATT_MTU - len(packet)  # fmt: skip

--- a/tests/test_gatt_characteristics.py
+++ b/tests/test_gatt_characteristics.py
@@ -1,10 +1,11 @@
 """Test for dynamic GATT characteristic selection."""
 
-from unittest.mock import Mock, AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 import pytest
 from bleak.backends.device import BLEDevice
 from custom_components.tuya_ble.tuya_ble import TuyaBLEDevice
 from custom_components.tuya_ble.tuya_ble.manager import TuyaBLEDeviceCredentials
+from custom_components.tuya_ble.tuya_ble.const import TuyaBLECode
 from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
@@ -127,6 +128,7 @@ async def test_gatt_characteristic_selection_fd50(hass: HomeAssistant) -> None:
         device = TuyaBLEDevice(manager, ble_device)
         await device.initialize()
         device._is_paired = True
+        device._protocol_version = 4
 
         # Mock Client
         client = Mock()
@@ -161,3 +163,85 @@ async def test_gatt_characteristic_selection_fd50(hass: HomeAssistant) -> None:
                 client.start_notify.assert_called_with(
                     "00000002-0000-1001-8001-00805f9b07d0", device._notification_handler
                 )
+                packets = device._build_packets(
+                    1,
+                    TuyaBLECode.FUN_SENDER_DEVICE_INFO,
+                    bytes(),
+                )
+                assert packets[0][2] == 0x40
+
+
+@pytest.mark.asyncio
+async def test_yzd02b_fd50_device_info_handshake(hass: HomeAssistant) -> None:
+    """Test the product-scoped TuyaOS login framing required by YZD02B."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": "11:22:33:44:55:66",
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(
+        name="bob", address="11:22:33:44:55:66", details="", rssi=-50
+    )
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    credentials = TuyaBLEDeviceCredentials(
+        uuid="12345678901234567890",
+        local_key="wV[NcWGUSFF`dSgO",
+        device_id="767823809c9c1f458745",
+        category="ggq",
+        product_id="jntxv3q4",
+        device_name="Dual smart irrigation timer",
+        product_model="YZD02B",
+        product_name="Dual smart irrigation timer",
+        functions=[],
+        status_range=[],
+    )
+
+    with patch.object(manager, "get_device_credentials", return_value=credentials):
+        device = TuyaBLEDevice(manager, ble_device)
+        await device.initialize()
+        device._is_paired = True
+        device._protocol_version = 4
+
+        client = Mock()
+        client.is_connected = True
+        client.start_notify = AsyncMock()
+        client.services.get_characteristic = Mock(
+            side_effect=lambda uuid: (
+                Mock() if uuid == "00000002-0000-1001-8001-00805f9b07d0" else None
+            )
+        )
+
+        with (
+            patch(
+                "custom_components.tuya_ble.tuya_ble.tuya_ble.establish_connection",
+                return_value=client,
+            ),
+            patch.object(
+                device, "_send_packet_while_connected", return_value=True
+            ) as send_packet,
+        ):
+            await device._ensure_connected()
+
+        client.start_notify.assert_awaited_once_with(
+            "00000002-0000-1001-8001-00805f9b07d0",
+            device._notification_handler,
+            bluez={"use_start_notify": True},
+        )
+        assert send_packet.await_args_list[0] == call(
+            TuyaBLECode.FUN_SENDER_DEVICE_INFO,
+            b"\x00\xf3",
+            0,
+            True,
+        )
+
+        packets = device._build_packets(
+            1,
+            TuyaBLECode.FUN_SENDER_DEVICE_INFO,
+            b"\x00\xf3",
+        )
+        assert packets[0][2] == 0x20


### PR DESCRIPTION
## Summary

- add product ID jntxv3q4 in category ggq
- map valves 105/104, countdowns 106/103, battery 11, and usage counters 111/110
- add the product-scoped FD50 notify and device-info handshake required by this controller
- keep the generic FD50 handshake unchanged for every other product

## Validation

- 23 tests pass on this standalone branch
- the combined three-PR series passes all 40 tests
- Black, codespell, JSON parsing, and git diff --check pass
- behavioral tests verify the BlueZ start-notify option, device-info payload 00f3, YZD02B protocol-v2 header, and unchanged generic FD50 protocol-v4 header
- live validation completed a one-minute cycle on each valve; both usage sensors reported 60 seconds, battery reported 98%, recorder history contains both cycles, the other valve stayed off, and Home Assistant logged no Tuya BLE errors

## Dependencies

Full runtime support requires both earlier parts of this independently reviewable series:

1. #254: generic v4 transport
2. #255: SecKey authentication and security levels 14/15
3. This PR: YZD02B mapping and product-scoped handshake