### PR TITLE
fix(sensor): Expose YZD02B zone work states

### DIFF
--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1301,13 +1301,53 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     ),
                 ),
             ],
+            "jntxv3q4": [  # YZD02B dual irrigation timer
+                TuyaBLEBatteryMapping(dp_id=11),
+                TuyaBLESensorMapping(
+                    dp_id=111,
+                    description=SensorEntityDescription(
+                        key="use_time_z1",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=110,
+                    description=SensorEntityDescription(
+                        key="use_time_z2",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=112,
+                    dp_type=TuyaBLEDataPointType.DT_ENUM,
+                    description=SensorEntityDescription(
+                        key="work_state_z1",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=["manual", "auto", "idle"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=113,
+                    dp_type=TuyaBLEDataPointType.DT_ENUM,
+                    description=SensorEntityDescription(
+                        key="work_state_z2",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=["manual", "auto", "idle"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+            ],
             **dict.fromkeys(
                 [
                     "hfgdqhho",
                     "qycalacn",
                     "fnlw6npo",
                     "jjqi2syk",
-                    "jntxv3q4",
                 ],  # Irrigation computer - dual outlet
                 [
                     TuyaBLEBatteryMapping(dp_id=11),

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -235,6 +235,12 @@
             "work_state": {
                 "name": "Work state"
             },
+            "work_state_z1": {
+                "name": "Work state - Zone 1"
+            },
+            "work_state_z2": {
+                "name": "Work state - Zone 2"
+            },
             "residual_electricity": {
                 "name": "Battery"
             },

--- a/custom_components/tuya_ble/translations/de.json
+++ b/custom_components/tuya_ble/translations/de.json
@@ -222,6 +222,12 @@
             "work_state": {
                 "name": "Betriebszustand"
             },
+            "work_state_z1": {
+                "name": "Betriebszustand - Zone 1"
+            },
+            "work_state_z2": {
+                "name": "Betriebszustand - Zone 2"
+            },
             "residual_electricity": {
                 "name": "Batterie"
             },

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -243,6 +243,12 @@
             "work_state": {
                 "name": "Work state"
             },
+            "work_state_z1": {
+                "name": "Work state - Zone 1"
+            },
+            "work_state_z2": {
+                "name": "Work state - Zone 2"
+            },
             "residual_electricity": {
                 "name": "Battery"
             },

--- a/custom_components/tuya_ble/translations/es.json
+++ b/custom_components/tuya_ble/translations/es.json
@@ -222,6 +222,12 @@
             "work_state": {
                 "name": "Estado de funcionamiento"
             },
+            "work_state_z1": {
+                "name": "Estado de funcionamiento - Zona 1"
+            },
+            "work_state_z2": {
+                "name": "Estado de funcionamiento - Zona 2"
+            },
             "residual_electricity": {
                 "name": "Batería"
             },

--- a/custom_components/tuya_ble/translations/fr.json
+++ b/custom_components/tuya_ble/translations/fr.json
@@ -222,6 +222,12 @@
             "work_state": {
                 "name": "État de fonctionnement"
             },
+            "work_state_z1": {
+                "name": "État de fonctionnement - Zone 1"
+            },
+            "work_state_z2": {
+                "name": "État de fonctionnement - Zone 2"
+            },
             "residual_electricity": {
                 "name": "Batterie"
             },

--- a/custom_components/tuya_ble/translations/it.json
+++ b/custom_components/tuya_ble/translations/it.json
@@ -222,6 +222,12 @@
             "work_state": {
                 "name": "Stato di funzionamento"
             },
+            "work_state_z1": {
+                "name": "Stato di funzionamento - Zona 1"
+            },
+            "work_state_z2": {
+                "name": "Stato di funzionamento - Zona 2"
+            },
             "residual_electricity": {
                 "name": "Batteria"
             },

--- a/custom_components/tuya_ble/translations/pt-BR.json
+++ b/custom_components/tuya_ble/translations/pt-BR.json
@@ -222,6 +222,12 @@
             "work_state": {
                 "name": "Estado de funcionamento"
             },
+            "work_state_z1": {
+                "name": "Estado de funcionamento - Zona 1"
+            },
+            "work_state_z2": {
+                "name": "Estado de funcionamento - Zona 2"
+            },
             "residual_electricity": {
                 "name": "Bateria"
             },

--- a/custom_components/tuya_ble/translations/zh-Hans.json
+++ b/custom_components/tuya_ble/translations/zh-Hans.json
@@ -222,6 +222,12 @@
             "work_state": {
                 "name": "工作状态"
             },
+            "work_state_z1": {
+                "name": "工作状态 - 区域 1"
+            },
+            "work_state_z2": {
+                "name": "工作状态 - 区域 2"
+            },
             "residual_electricity": {
                 "name": "电量"
             },


### PR DESCRIPTION
## Summary

- give the YZD02B (`jntxv3q4`) its own irrigation-sensor mapping while retaining battery and per-zone usage duration sensors
- expose diagnostic enum sensors for DP 112 (`work_state_z1`) and DP 113 (`work_state_z2`)
- use the device order `manual`, `auto`, `idle` and force entity creation because these datapoints are absent from the Tuya Cloud specification
- add translated Zone 1/2 work-state names to every existing translation file

## Mapping evidence

A read-only Tuya Cloud specifications query for the paired device omits DPs 112 and 113, although both are reported over BLE. The mapping and enum order are independently corroborated by [`diivoo_wt05.yaml` in tuya-local](https://github.com/make-all/tuya-local/blob/e8b2530da53eec3bafb0dcbef024f3e06415d1b2/custom_components/tuya_local/devices/diivoo_wt05.yaml).

Live validation on a YZD02B showed:

- Zone 1: `idle -> manual -> idle`, valve `off -> on -> off`, usage duration `60 s`; Zone 2 stayed off
- Zone 2: `idle -> manual -> idle`, valve `off -> on -> off`, usage duration `60 s`; Zone 1 stayed off
- both valves finished off and both work-state sensors finished idle

The live deployment used a local, unpublished validation branch combining this commit with the independent weather-delay commit; the deployed source manifest matched that branch exactly.

## Validation

Per the repository guidance for simple mappings, this PR does not add committed tests. I ran an untracked mapping smoke check plus:

- `pytest --cov --disable-warnings -s`: 40 passed, 99% coverage
- `black --check --diff .`
- `codespell`
- JSON parsing for all modified translation files
- `git diff --check`
- Hassfest: 1 integration, 0 invalid
- HACS validation: all 9 checks passed
- live Home Assistant core config check, restart, entity-state/history checks, and focused BLE log inspection

Raw schedule DPs 101/102 are intentionally out of scope. This PR is independent from the companion weather-delay mapping PR #258.

