### PR TITLE
fix(select): Expose YZD02B weather delays

### DIFF
--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -235,6 +235,48 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
             ],
         },
     ),
+    "ggq": TuyaBLECategorySelectMapping(
+        products={
+            "jntxv3q4": [  # YZD02B dual irrigation timer
+                TuyaBLESelectMapping(
+                    dp_id=117,
+                    dp_type=TuyaBLEDataPointType.DT_ENUM,
+                    description=SelectEntityDescription(
+                        key="weather_delay_z1",
+                        options=[
+                            "cancel",
+                            "24h",
+                            "48h",
+                            "72h",
+                            "96h",
+                            "120h",
+                            "144h",
+                            "168h",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESelectMapping(
+                    dp_id=114,
+                    dp_type=TuyaBLEDataPointType.DT_ENUM,
+                    description=SelectEntityDescription(
+                        key="weather_delay_z2",
+                        options=[
+                            "cancel",
+                            "24h",
+                            "48h",
+                            "72h",
+                            "96h",
+                            "120h",
+                            "144h",
+                            "168h",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+            ],
+        },
+    ),
     "co2bj": TuyaBLECategorySelectMapping(
         products={
             "59s19z5m": [TuyaBLETemperatureUnitMapping(dp_id=101)],  # CO2 Detector

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -137,6 +137,12 @@
             "weather_delay": {
                 "name": "Weather delay"
             },
+            "weather_delay_z1": {
+                "name": "Weather delay - Zone 1"
+            },
+            "weather_delay_z2": {
+                "name": "Weather delay - Zone 2"
+            },
             "smart_weather": {
                 "name": "Smart weather"
             },

--- a/custom_components/tuya_ble/translations/de.json
+++ b/custom_components/tuya_ble/translations/de.json
@@ -136,6 +136,12 @@
             "weather_delay": {
                 "name": "Wetterverzögerung"
             },
+            "weather_delay_z1": {
+                "name": "Wetterverzögerung - Zone 1"
+            },
+            "weather_delay_z2": {
+                "name": "Wetterverzögerung - Zone 2"
+            },
             "smart_weather": {
                 "name": "Intelligentes Wetter"
             },

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -137,6 +137,12 @@
             "weather_delay": {
                 "name": "Weather delay"
             },
+            "weather_delay_z1": {
+                "name": "Weather delay - Zone 1"
+            },
+            "weather_delay_z2": {
+                "name": "Weather delay - Zone 2"
+            },
             "smart_weather": {
                 "name": "Smart weather"
             },

--- a/custom_components/tuya_ble/translations/es.json
+++ b/custom_components/tuya_ble/translations/es.json
@@ -136,6 +136,12 @@
             "weather_delay": {
                 "name": "Retraso meteorológico"
             },
+            "weather_delay_z1": {
+                "name": "Retraso meteorológico - Zona 1"
+            },
+            "weather_delay_z2": {
+                "name": "Retraso meteorológico - Zona 2"
+            },
             "smart_weather": {
                 "name": "Clima inteligente"
             },

--- a/custom_components/tuya_ble/translations/fr.json
+++ b/custom_components/tuya_ble/translations/fr.json
@@ -136,6 +136,12 @@
             "weather_delay": {
                 "name": "Délai météo"
             },
+            "weather_delay_z1": {
+                "name": "Délai météo - Zone 1"
+            },
+            "weather_delay_z2": {
+                "name": "Délai météo - Zone 2"
+            },
             "smart_weather": {
                 "name": "Météo intelligente"
             },

--- a/custom_components/tuya_ble/translations/it.json
+++ b/custom_components/tuya_ble/translations/it.json
@@ -136,6 +136,12 @@
             "weather_delay": {
                 "name": "Ritardo meteorologico"
             },
+            "weather_delay_z1": {
+                "name": "Ritardo meteorologico - Zona 1"
+            },
+            "weather_delay_z2": {
+                "name": "Ritardo meteorologico - Zona 2"
+            },
             "smart_weather": {
                 "name": "Meteo intelligente"
             },

--- a/custom_components/tuya_ble/translations/pt-BR.json
+++ b/custom_components/tuya_ble/translations/pt-BR.json
@@ -136,6 +136,12 @@
             "weather_delay": {
                 "name": "Atraso devido ao clima"
             },
+            "weather_delay_z1": {
+                "name": "Atraso devido ao clima - Zona 1"
+            },
+            "weather_delay_z2": {
+                "name": "Atraso devido ao clima - Zona 2"
+            },
             "smart_weather": {
                 "name": "Clima inteligente"
             },

--- a/custom_components/tuya_ble/translations/zh-Hans.json
+++ b/custom_components/tuya_ble/translations/zh-Hans.json
@@ -136,6 +136,12 @@
             "weather_delay": {
                 "name": "天气延时"
             },
+            "weather_delay_z1": {
+                "name": "天气延时 - 区域 1"
+            },
+            "weather_delay_z2": {
+                "name": "天气延时 - 区域 2"
+            },
             "smart_weather": {
                 "name": "智能天气"
             },


### PR DESCRIPTION
## Summary

- expose YZD02B (`jntxv3q4`) configuration selects for DP 117 (`weather_delay_z1`) and DP 114 (`weather_delay_z2`)
- map enum indices to `cancel`, `24h`, `48h`, `72h`, `96h`, `120h`, `144h`, `168h`
- use distinct Zone 1/2 translation keys so the entity unique IDs cannot collide
- force entity creation because these datapoints are absent from the Tuya Cloud specification
- add translated Zone 1/2 weather-delay names to every existing translation file

## Mapping evidence

A read-only Tuya Cloud specifications query for the paired device omits DPs 114 and 117. The IDs and option order are independently corroborated by [`diivoo_wt05.yaml` in tuya-local](https://github.com/make-all/tuya-local/blob/e8b2530da53eec3bafb0dcbef024f3e06415d1b2/custom_components/tuya_local/devices/diivoo_wt05.yaml).

Live validation on a YZD02B showed:

- Zone 1: `cancel -> 24h -> cancel`; BLE logs showed DP 117 enum values `1 -> 0`, successful protocol acknowledgements (`result: 0`), and matching device reports
- Zone 2: `cancel -> 24h -> cancel`; BLE logs showed DP 114 enum values `1 -> 0`, successful protocol acknowledgements (`result: 0`), and matching device reports
- both valves remained off throughout; both selects finished at `cancel`
- the focused final validation window contained no Tuya BLE warnings or errors

The live deployment used a local, unpublished validation branch combining this commit with the independent zone-work-state commit; the deployed source manifest matched that branch exactly.

## Validation

Per the repository guidance for simple mappings, this PR does not add committed tests. I ran an untracked mapping smoke check plus:

- `pytest --cov --disable-warnings -s`: 40 passed, 99% coverage
- `black --check --diff .`
- `codespell`
- JSON parsing for all modified translation files
- `git diff --check`
- Hassfest: 1 integration, 0 invalid
- HACS validation: all 9 checks passed
- live Home Assistant core config check, restart, state/history checks, reversible write checks, and focused BLE log inspection

This PR is independent from #257. Raw schedule DPs 101/102 are intentionally out of scope.
