### PR TITLE
fix(device): Add support for Dituo DT-T2190A Aroma Diffuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,13 @@ the optional **Tuya BLE SecKey** field when configuring such a device.
       <td><code>ajrhf1aj</code></td>
       <td>—</td>
     </tr>
+    <tr>
+      <td><strong>Humidifier</strong></td>
+      <td><code>jsq</code></td>
+      <td>Dituo DT-T2190A Aroma Diffuser</td>
+      <td><code>if1nolcm</code></td>
+      <td>—</td>
+    </tr>
   </tbody>
 </table>
 

--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -338,6 +338,29 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
             ],
         },
     ),
+    "jsq": TuyaBLECategoryBinarySensorMapping(
+        products={
+            "if1nolcm": [
+                TuyaBLEBinarySensorMapping(
+                    dp_id=12,
+                    description=BinarySensorEntityDescription(
+                        key="fault",
+                        device_class=BinarySensorDeviceClass.PROBLEM,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                    getter=lambda sensor: setattr(
+                        sensor,
+                        "_attr_is_on",
+                        bool(
+                            _bitmap_value_to_int(sensor._device.datapoints[12].value)
+                            if sensor._device.datapoints[12]
+                            else False
+                        ),
+                    ),
+                ),
+            ],
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -726,6 +726,14 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             ),
         },
     ),
+    "jsq": TuyaBLECategoryInfo(
+        products={
+            "if1nolcm": TuyaBLEProductInfo(
+                name="DT-T2190A Aroma Diffuser",
+                manufacturer="Dituo",
+            ),
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/light.py
+++ b/custom_components/tuya_ble/light.py
@@ -142,7 +142,22 @@ ProductsMapping: dict[str, dict[str, tuple[TuyaLightEntityDescription, ...]]] = 
                 },
             ),
         )
-    }
+    },
+    "jsq": {
+        "if1nolcm": (
+            TuyaLightEntityDescription(
+                key=DPCode.SWITCH_LED,
+                name=None,
+                color_mode=DPCode.WORK_MODE,
+                brightness=(DPCode.BRIGHT_VALUE_V2, DPCode.BRIGHT_VALUE),
+                color_data=(
+                    DPCode.COLOUR_DATA_V2,
+                    DPCode.COLOUR_DATA,
+                    DPCode.COLOUR_DATA_HSV,
+                ),
+            ),
+        )
+    },
 }
 
 # Copied from standard Tuya light component - we could add some default values here too
@@ -248,8 +263,12 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
             key=DPCode.SWITCH_LED,
             name=None,
             color_mode=DPCode.WORK_MODE,
-            brightness=DPCode.BRIGHT_VALUE,
-            color_data=DPCode.COLOUR_DATA_HSV,
+            brightness=(DPCode.BRIGHT_VALUE_V2, DPCode.BRIGHT_VALUE),
+            color_data=(
+                DPCode.COLOUR_DATA_V2,
+                DPCode.COLOUR_DATA,
+                DPCode.COLOUR_DATA_HSV,
+            ),
         ),
     ),
     # Switch

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -695,6 +695,53 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
             ],
         },
     ),
+    "jsq": TuyaBLECategorySelectMapping(
+        products={
+            "if1nolcm": [
+                TuyaBLESelectMapping(
+                    dp_id=3,
+                    description=SelectEntityDescription(
+                        key="spray_mode",
+                        options=[
+                            "small",
+                            "large",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESelectMapping(
+                    dp_id=5,
+                    description=SelectEntityDescription(
+                        key="timer",
+                        options=[
+                            "cancel",
+                            "1h",
+                            "3h",
+                            "6h",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESelectMapping(
+                    dp_id=101,
+                    description=SelectEntityDescription(
+                        key="scene",
+                        options=[
+                            "night",
+                            "read",
+                            "work",
+                            "rest",
+                            "grassland",
+                            "colorful",
+                            "Dazzle",
+                            "gorgeous",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+            ],
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -733,7 +733,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                             "rest",
                             "grassland",
                             "colorful",
-                            "Dazzle",
+                            "dazzle",
                             "gorgeous",
                         ],
                         entity_category=EntityCategory.CONFIG,

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1743,6 +1743,22 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
             ]
         }
     ),
+    "jsq": TuyaBLECategorySensorMapping(
+        products={
+            "if1nolcm": [
+                TuyaBLESensorMapping(
+                    dp_id=6,
+                    description=SensorEntityDescription(
+                        key="time_remaining",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+            ],
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -175,6 +175,35 @@
                     "turn_right": "Turn right",
                     "stop": "Stop"
                 }
+            },
+            "timer": {
+                "name": "Timer",
+                "state": {
+                    "cancel": "Cancel",
+                    "1h": "1 hour",
+                    "3h": "3 hours",
+                    "6h": "6 hours"
+                }
+            },
+            "scene": {
+                "name": "Scene",
+                "state": {
+                    "night": "Night",
+                    "read": "Reading",
+                    "work": "Working",
+                    "rest": "Relax",
+                    "grassland": "Grassland",
+                    "colorful": "Party",
+                    "Dazzle": "Dazzle",
+                    "gorgeous": "Gorgeous"
+                }
+            },
+            "spray_mode": {
+                "name": "Spray mode",
+                "state": {
+                    "small": "Low",
+                    "large": "High"
+                }
             }
         },
         "sensor": {
@@ -309,6 +338,9 @@
             },
             "unlock_phone_remote": {
                 "name": "Last used remote phone"
+            },
+            "time_remaining": {
+                "name": "Time remaining"
             }
         },
         "switch": {
@@ -377,6 +409,9 @@
             },
             "water_auto": {
                 "name": "Auto water spray"
+            },
+            "switch_spray": {
+                "name": "Spraying"
             }
         },
         "text": {

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -194,8 +194,8 @@
                     "rest": "Relax",
                     "grassland": "Grassland",
                     "colorful": "Party",
-                    "Dazzle": "Dazzle",
-                    "gorgeous": "Gorgeous"
+                    "gorgeous": "Gorgeous",
+                    "dazzle": "Dazzle"
                 }
             },
             "spray_mode": {

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -297,6 +297,26 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
             ],
         },
     ),
+    "jsq": TuyaBLECategorySwitchMapping(
+        products={
+            "if1nolcm": [
+                TuyaBLESwitchMapping(
+                    dp_id=1,
+                    description=SwitchEntityDescription(
+                        key="switch",
+                        icon="mdi:power",
+                    ),
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=2,
+                    description=SwitchEntityDescription(
+                        key="switch_spray",
+                        icon="mdi:spray",
+                    ),
+                ),
+            ],
+        },
+    ),
     "ms": TuyaBLECategorySwitchMapping(
         products={
             **dict.fromkeys(

--- a/custom_components/tuya_ble/translations/de.json
+++ b/custom_components/tuya_ble/translations/de.json
@@ -154,6 +154,35 @@
             },
             "temperature_unit": {
                 "name": "Temperatureinheit"
+            },
+            "timer": {
+                "name": "Timer",
+                "state": {
+                    "cancel": "Abbrechen",
+                    "1h": "1 Stunde",
+                    "3h": "3 Stunden",
+                    "6h": "6 Stunden"
+                }
+            },
+            "scene": {
+                "name": "Szene",
+                "state": {
+                    "night": "Nacht",
+                    "read": "Lesen",
+                    "work": "Arbeiten",
+                    "rest": "Entspannen",
+                    "grassland": "Wiese",
+                    "colorful": "Party",
+                    "Dazzle": "Flackern",
+                    "gorgeous": "Prachtvoll"
+                }
+            },
+            "spray_mode": {
+                "name": "Sprühmodus",
+                "state": {
+                    "small": "Niedrig",
+                    "large": "Hoch"
+                }
             }
         },
         "sensor": {
@@ -302,6 +331,9 @@
             },
             "unlock_temp_pwd": {
                 "name": "Zuletzt verwendetes temporäres Passwort"
+            },
+            "time_remaining": {
+                "name": "Restzeit"
             }
         },
         "switch": {
@@ -361,6 +393,9 @@
             },
             "window_check": {
                 "name": "Fensterprüfung"
+            },
+            "switch_spray": {
+                "name": "Sprühen"
             }
         },
         "text": {

--- a/custom_components/tuya_ble/translations/de.json
+++ b/custom_components/tuya_ble/translations/de.json
@@ -173,8 +173,8 @@
                     "rest": "Entspannen",
                     "grassland": "Wiese",
                     "colorful": "Party",
-                    "Dazzle": "Flackern",
-                    "gorgeous": "Prachtvoll"
+                    "gorgeous": "Prachtvoll",
+                    "dazzle": "Flackern"
                 }
             },
             "spray_mode": {

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -194,8 +194,8 @@
                     "rest": "Relax",
                     "grassland": "Grassland",
                     "colorful": "Party",
-                    "Dazzle": "Dazzle",
-                    "gorgeous": "Gorgeous"
+                    "gorgeous": "Gorgeous",
+                    "dazzle": "Dazzle"
                 }
             },
             "spray_mode": {

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -175,6 +175,35 @@
                     "turn_right": "Turn right",
                     "stop": "Stop"
                 }
+            },
+            "timer": {
+                "name": "Timer",
+                "state": {
+                    "cancel": "Cancel",
+                    "1h": "1 hour",
+                    "3h": "3 hours",
+                    "6h": "6 hours"
+                }
+            },
+            "scene": {
+                "name": "Scene",
+                "state": {
+                    "night": "Night",
+                    "read": "Reading",
+                    "work": "Working",
+                    "rest": "Relax",
+                    "grassland": "Grassland",
+                    "colorful": "Party",
+                    "Dazzle": "Dazzle",
+                    "gorgeous": "Gorgeous"
+                }
+            },
+            "spray_mode": {
+                "name": "Spray mode",
+                "state": {
+                    "small": "Low",
+                    "large": "High"
+                }
             }
         },
         "sensor": {
@@ -323,6 +352,9 @@
             },
             "unlock_temp_pwd": {
                 "name": "Last used Temporary Password"
+            },
+            "time_remaining": {
+                "name": "Time remaining"
             }
         },
         "switch": {
@@ -391,6 +423,9 @@
             },
             "water_auto": {
                 "name": "Auto water spray"
+            },
+            "switch_spray": {
+                "name": "Spraying"
             }
         },
         "text": {

--- a/custom_components/tuya_ble/translations/es.json
+++ b/custom_components/tuya_ble/translations/es.json
@@ -173,8 +173,8 @@
                     "rest": "Relajación",
                     "grassland": "Pradera",
                     "colorful": "Fiesta",
-                    "Dazzle": "Deslumbrante",
-                    "gorgeous": "Magnífico"
+                    "gorgeous": "Magnífico",
+                    "dazzle": "Deslumbrante"
                 }
             },
             "spray_mode": {

--- a/custom_components/tuya_ble/translations/es.json
+++ b/custom_components/tuya_ble/translations/es.json
@@ -154,6 +154,35 @@
             },
             "temperature_unit": {
                 "name": "Unidad de temperatura"
+            },
+            "timer": {
+                "name": "Temporizador",
+                "state": {
+                    "cancel": "Cancelar",
+                    "1h": "1 hora",
+                    "3h": "3 horas",
+                    "6h": "6 horas"
+                }
+            },
+            "scene": {
+                "name": "Escena",
+                "state": {
+                    "night": "Noche",
+                    "read": "Lectura",
+                    "work": "Trabajo",
+                    "rest": "Relajación",
+                    "grassland": "Pradera",
+                    "colorful": "Fiesta",
+                    "Dazzle": "Deslumbrante",
+                    "gorgeous": "Magnífico"
+                }
+            },
+            "spray_mode": {
+                "name": "Modo de pulverización",
+                "state": {
+                    "small": "Bajo",
+                    "large": "Alto"
+                }
             }
         },
         "sensor": {
@@ -302,6 +331,9 @@
             },
             "unlock_temp_pwd": {
                 "name": "Última contraseña temporal utilizada"
+            },
+            "time_remaining": {
+                "name": "Tiempo restante"
             }
         },
         "switch": {
@@ -361,6 +393,9 @@
             },
             "window_check": {
                 "name": "Detección de ventanas"
+            },
+            "switch_spray": {
+                "name": "Pulverización"
             }
         },
         "text": {

--- a/custom_components/tuya_ble/translations/fr.json
+++ b/custom_components/tuya_ble/translations/fr.json
@@ -154,6 +154,35 @@
             },
             "temperature_unit": {
                 "name": "Unité de température"
+            },
+            "timer": {
+                "name": "Minuterie",
+                "state": {
+                    "cancel": "Annuler",
+                    "1h": "1 heure",
+                    "3h": "3 heures",
+                    "6h": "6 heures"
+                }
+            },
+            "scene": {
+                "name": "Scène",
+                "state": {
+                    "night": "Nuit",
+                    "read": "Lecture",
+                    "work": "Travail",
+                    "rest": "Relaxation",
+                    "grassland": "Prairie",
+                    "colorful": "Fête",
+                    "Dazzle": "Éblouissant",
+                    "gorgeous": "Magnifique"
+                }
+            },
+            "spray_mode": {
+                "name": "Mode de pulvérisation",
+                "state": {
+                    "small": "Bas",
+                    "large": "Élevé"
+                }
             }
         },
         "sensor": {
@@ -302,6 +331,9 @@
             },
             "unlock_temp_pwd": {
                 "name": "Dernier mot de passe temporaire utilisé"
+            },
+            "time_remaining": {
+                "name": "Temps restant"
             }
         },
         "switch": {
@@ -361,6 +393,9 @@
             },
             "window_check": {
                 "name": "Détection de fenêtre"
+            },
+            "switch_spray": {
+                "name": "Pulvérisation"
             }
         },
         "text": {

--- a/custom_components/tuya_ble/translations/fr.json
+++ b/custom_components/tuya_ble/translations/fr.json
@@ -173,8 +173,8 @@
                     "rest": "Relaxation",
                     "grassland": "Prairie",
                     "colorful": "Fête",
-                    "Dazzle": "Éblouissant",
-                    "gorgeous": "Magnifique"
+                    "gorgeous": "Magnifique",
+                    "dazzle": "Éblouissant"
                 }
             },
             "spray_mode": {

--- a/custom_components/tuya_ble/translations/it.json
+++ b/custom_components/tuya_ble/translations/it.json
@@ -154,6 +154,35 @@
             },
             "temperature_unit": {
                 "name": "Unità di misura della temperatura"
+            },
+            "timer": {
+                "name": "Timer",
+                "state": {
+                    "cancel": "Annulla",
+                    "1h": "1 ora",
+                    "3h": "3 ore",
+                    "6h": "6 ore"
+                }
+            },
+            "scene": {
+                "name": "Scena",
+                "state": {
+                    "night": "Notte",
+                    "read": "Lettura",
+                    "work": "Lavoro",
+                    "rest": "Relax",
+                    "grassland": "Prato",
+                    "colorful": "Festa",
+                    "Dazzle": "Abbagliante",
+                    "gorgeous": "Splendido"
+                }
+            },
+            "spray_mode": {
+                "name": "Modalità di spruzzo",
+                "state": {
+                    "small": "Basso",
+                    "large": "Alto"
+                }
             }
         },
         "sensor": {
@@ -302,6 +331,9 @@
             },
             "unlock_temp_pwd": {
                 "name": "Ultima password temporanea utilizzata"
+            },
+            "time_remaining": {
+                "name": "Tempo rimanente"
             }
         },
         "switch": {
@@ -361,6 +393,9 @@
             },
             "window_check": {
                 "name": "Rilevamento finestra aperta"
+            },
+            "switch_spray": {
+                "name": "Spruzzatura"
             }
         },
         "text": {

--- a/custom_components/tuya_ble/translations/it.json
+++ b/custom_components/tuya_ble/translations/it.json
@@ -173,8 +173,8 @@
                     "rest": "Relax",
                     "grassland": "Prato",
                     "colorful": "Festa",
-                    "Dazzle": "Abbagliante",
-                    "gorgeous": "Splendido"
+                    "gorgeous": "Splendido",
+                    "dazzle": "Abbagliante"
                 }
             },
             "spray_mode": {

--- a/custom_components/tuya_ble/translations/pt-BR.json
+++ b/custom_components/tuya_ble/translations/pt-BR.json
@@ -173,8 +173,8 @@
                     "rest": "Relaxar",
                     "grassland": "Gramado",
                     "colorful": "Festa",
-                    "Dazzle": "Ofuscante",
-                    "gorgeous": "Deslumbrante"
+                    "gorgeous": "Deslumbrante",
+                    "dazzle": "Ofuscante"
                 }
             },
             "spray_mode": {

--- a/custom_components/tuya_ble/translations/pt-BR.json
+++ b/custom_components/tuya_ble/translations/pt-BR.json
@@ -154,6 +154,35 @@
             },
             "temperature_unit": {
                 "name": "Unidade de temperatura"
+            },
+            "timer": {
+                "name": "Temporizador",
+                "state": {
+                    "cancel": "Cancelar",
+                    "1h": "1 hora",
+                    "3h": "3 horas",
+                    "6h": "6 horas"
+                }
+            },
+            "scene": {
+                "name": "Cena",
+                "state": {
+                    "night": "Noite",
+                    "read": "Leitura",
+                    "work": "Trabalho",
+                    "rest": "Relaxar",
+                    "grassland": "Gramado",
+                    "colorful": "Festa",
+                    "Dazzle": "Ofuscante",
+                    "gorgeous": "Deslumbrante"
+                }
+            },
+            "spray_mode": {
+                "name": "Modo de pulverização",
+                "state": {
+                    "small": "Baixo",
+                    "large": "Alto"
+                }
             }
         },
         "sensor": {
@@ -302,6 +331,9 @@
             },
             "unlock_temp_pwd": {
                 "name": "Última senha temporária utilizada"
+            },
+            "time_remaining": {
+                "name": "Tempo restante"
             }
         },
         "switch": {
@@ -361,6 +393,9 @@
             },
             "window_check": {
                 "name": "Detecção de janela"
+            },
+            "switch_spray": {
+                "name": "Pulverização"
             }
         },
         "text": {

--- a/custom_components/tuya_ble/translations/zh-Hans.json
+++ b/custom_components/tuya_ble/translations/zh-Hans.json
@@ -173,8 +173,8 @@
                     "rest": "休闲",
                     "grassland": "草原",
                     "colorful": "派对",
-                    "Dazzle": "炫彩",
-                    "gorgeous": "华丽"
+                    "gorgeous": "华丽",
+                    "dazzle": "炫彩"
                 }
             },
             "spray_mode": {

--- a/custom_components/tuya_ble/translations/zh-Hans.json
+++ b/custom_components/tuya_ble/translations/zh-Hans.json
@@ -154,6 +154,35 @@
             },
             "temperature_unit": {
                 "name": "温度单位"
+            },
+            "timer": {
+                "name": "定时",
+                "state": {
+                    "cancel": "取消",
+                    "1h": "1小时",
+                    "3h": "3小时",
+                    "6h": "6小时"
+                }
+            },
+            "scene": {
+                "name": "场景",
+                "state": {
+                    "night": "夜晚",
+                    "read": "阅读",
+                    "work": "工作",
+                    "rest": "休闲",
+                    "grassland": "草原",
+                    "colorful": "派对",
+                    "Dazzle": "炫彩",
+                    "gorgeous": "华丽"
+                }
+            },
+            "spray_mode": {
+                "name": "喷雾模式",
+                "state": {
+                    "small": "小",
+                    "large": "大"
+                }
             }
         },
         "sensor": {
@@ -302,6 +331,9 @@
             },
             "unlock_temp_pwd": {
                 "name": "上次使用的临时密码"
+            },
+            "time_remaining": {
+                "name": "剩余时间"
             }
         },
         "switch": {
@@ -361,6 +393,9 @@
             },
             "window_check": {
                 "name": "开窗检测"
+            },
+            "switch_spray": {
+                "name": "喷雾"
             }
         },
         "text": {


### PR DESCRIPTION
Added support for the Dituo DT-T2190A Aroma Diffuser (product id if1nolcm) under a new jsq (humidifier) category, including switches, selects, sensors, binary sensors, and light entities. Translated strings across all languages and updated the supported devices table in README.md.

---
*PR created automatically by Jules for task [7868809052509123581](https://jules.google.com/task/7868809052509123581) started by @CloCkWeRX*