### PR TITLE
fix(device): Add support for wkf climate category and llflaywg TRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,16 @@ the optional **Tuya BLE SecKey** field when configuring such a device.
       <td>—</td>
     </tr>
     <tr>
-      <td><strong>Climate</strong></td>
+      <td rowspan="2"><strong>Climate</strong></td>
       <td><code>wk</code></td>
       <td>Thermostatic Radiator Valve</td>
       <td><code>drlajpqc</code>, <code>nhj2j7su</code>, <code>zmachryv</code></td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td><code>wkf</code></td>
+      <td>Thermostatic Radiator Valve</td>
+      <td><code>llflaywg</code></td>
       <td>—</td>
     </tr>
     <tr>

--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -96,6 +96,26 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
             ),
         },
     ),
+    "wkf": TuyaBLECategoryBinarySensorMapping(
+        products={
+            **dict.fromkeys(
+                [
+                    "llflaywg",
+                ],
+                [  # Thermostatic Radiator Valve
+                    TuyaBLEBinarySensorMapping(
+                        dp_id=105,
+                        description=BinarySensorEntityDescription(
+                            key="battery",
+                            # icon="mdi:battery-alert",
+                            device_class=BinarySensorDeviceClass.BATTERY,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                        ),
+                    )
+                ],
+            ),
+        },
+    ),
     "wk": TuyaBLECategoryBinarySensorMapping(
         products={
             **dict.fromkeys(

--- a/custom_components/tuya_ble/climate.py
+++ b/custom_components/tuya_ble/climate.py
@@ -132,6 +132,34 @@ mapping: dict[str, TuyaBLECategoryClimateMapping] = {
             ),
         },
     ),
+    "wkf": TuyaBLECategoryClimateMapping(
+        products={
+            **dict.fromkeys(
+                [
+                    "llflaywg",
+                ],  # Thermostatic Radiator Valve
+                [
+                    # Thermostatic Radiator Valve
+                    TuyaBLEClimateMapping(
+                        description=ClimateEntityDescription(
+                            key="thermostatic_radiator_valve",
+                        ),
+                        hvac_switch_dp_id=101,
+                        hvac_switch_mode=HVACMode.HEAT,
+                        hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+                        preset_mode_dp_ids={PRESET_AWAY: 106, PRESET_NONE: 106},
+                        current_temperature_dp_id=102,
+                        current_temperature_coefficient=10.0,
+                        target_temperature_coefficient=10.0,
+                        target_temperature_step=0.5,
+                        target_temperature_dp_id=103,
+                        target_temperature_min=5.0,
+                        target_temperature_max=30.0,
+                    ),
+                ],
+            ),
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -354,6 +354,18 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             ),
         },
     ),
+    "wkf": TuyaBLECategoryInfo(
+        products={
+            **dict.fromkeys(
+                [
+                    "llflaywg",
+                ],  # device product_id
+                TuyaBLEProductInfo(
+                    name="Thermostatic Radiator Valve",
+                ),
+            ),
+        },
+    ),
     "wxkg": TuyaBLECategoryInfo(
         products={
             "kpzc6pm8": TuyaBLEProductInfo(

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -323,6 +323,29 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
             ),
         },
     ),
+    "wkf": TuyaBLECategoryNumberMapping(
+        products={
+            **dict.fromkeys(
+                [
+                    "llflaywg",
+                ],  # Thermostatic Radiator Valve
+                [
+                    TuyaBLENumberMapping(
+                        dp_id=27,
+                        description=NumberEntityDescription(
+                            key="temperature_calibration",
+                            icon="mdi:thermometer-lines",
+                            native_max_value=6,
+                            native_min_value=-6,
+                            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+                            native_step=1,
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                ],
+            ),
+        },
+    ),
     "szjqr": TuyaBLECategoryNumberMapping(
         products={
             **dict.fromkeys(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -292,6 +292,65 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
             ),
         },
     ),
+    "wkf": TuyaBLECategorySwitchMapping(
+        products={
+            **dict.fromkeys(
+                [
+                    "llflaywg",
+                ],  # Thermostatic Radiator Valve
+                [
+                    TuyaBLESwitchMapping(
+                        dp_id=8,
+                        description=SwitchEntityDescription(
+                            key="window_check",
+                            icon="mdi:window-closed",
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                    TuyaBLESwitchMapping(
+                        dp_id=10,
+                        description=SwitchEntityDescription(
+                            key="antifreeze",
+                            icon="mdi:snowflake-off",
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                    TuyaBLESwitchMapping(
+                        dp_id=40,
+                        description=SwitchEntityDescription(
+                            key="child_lock",
+                            icon="mdi:account-lock",
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                    TuyaBLESwitchMapping(
+                        dp_id=130,
+                        description=SwitchEntityDescription(
+                            key="water_scale_proof",
+                            icon="mdi:water-check",
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                    TuyaBLESwitchMapping(
+                        dp_id=107,
+                        description=SwitchEntityDescription(
+                            key="programming_mode",
+                            icon="mdi:calendar-edit",
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                    TuyaBLESwitchMapping(
+                        dp_id=108,
+                        description=SwitchEntityDescription(
+                            key="programming_switch",
+                            icon="mdi:calendar-clock",
+                            entity_category=EntityCategory.CONFIG,
+                        ),
+                    ),
+                ],
+            ),
+        },
+    ),
     "co2bj": TuyaBLECategorySwitchMapping(
         products={
             "59s19z5m": [  # CO2 Detector


### PR DESCRIPTION
This PR adds support for the wkf category and the llflaywg device (Thermostatic Radiator Valve) by duplicating the standard wk category mappings and product definitions under wkf, preserving existing wk mappings intact. Also updates README.md.

---
*PR created automatically by Jules for task [338233888814833960](https://jules.google.com/task/338233888814833960) started by @CloCkWeRX*