### PR TITLE
fix: add support for Arlec Smart Button SG022HA - Experimental

### DIFF
--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -370,7 +370,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
     ),
     "wxkg": TuyaBLECategoryInfo(
         products={
-            "kpzc6pm8": TuyaBLEProductInfo(
+            "kpzc6pm8": TuyaBLEProductInfo(  # Arlec Smart Button SG022HA (issue #204)
                 name="Arlec Smart Button",
                 manufacturer="Arlec",
             ),


### PR DESCRIPTION
Adds explicit documentation reference to Issue #204 in devices.py next to the Arlec Smart Button SG022HA (kpzc6pm8) configuration.

---
*PR created automatically by Jules for task [16017372961480057162](https://jules.google.com/task/16017372961480057162) started by @CloCkWeRX*