### PR TITLE
fix: mapping bug for wgv4haro Guard Dog Security Smart Lock

### DIFF
--- a/custom_components/tuya_ble/lock.py
+++ b/custom_components/tuya_ble/lock.py
@@ -81,6 +81,12 @@ class TuyaBLELock(TuyaBLEEntity, LockEntity):
                 False,
             ):
                 await motor_state.set_value(False)
+        elif self._device.product_id == "wgv4haro":
+            # Guard Dog Security Smart Lock locks automatically, locking command is no-op
+            # NOTE: Other momentary locks in category ms/jtmspro (like okkyfgfs, k53ok3u9,
+            # sidhzylo, a6nttc41, stugc8dl, xicdxood, rlyxv7pe, oyqux5vv, hs21i377, kholoaew)
+            # may also need updating in the future.
+            return
         else:
             if manual_lock := self._device.datapoints.get_or_create(
                 DPCode.MANUAL_LOCK, TuyaBLEDataPointType.DT_BOOL, True
@@ -102,6 +108,15 @@ class TuyaBLELock(TuyaBLEEntity, LockEntity):
                 True,
             ):
                 await motor_state.set_value(True)
+        elif self._device.product_id == "wgv4haro":
+            # Guard Dog Security Smart Lock uses DP 6 for bluetooth unlock
+            # NOTE: Other momentary locks (e.g. okkyfgfs, k53ok3u9, sidhzylo, a6nttc41 on DP 6;
+            # or stugc8dl, xicdxood, rlyxv7pe, oyqux5vv, hs21i377, kholoaew on DP 71)
+            # may also need updating in the future.
+            if bluetooth_unlock := self._device.datapoints.get_or_create(
+                6, TuyaBLEDataPointType.DT_BOOL, False
+            ):
+                await bluetooth_unlock.set_value(True)
         else:
             if manual_lock := self._device.datapoints.get_or_create(
                 DPCode.MANUAL_LOCK, TuyaBLEDataPointType.DT_BOOL, False

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -179,17 +179,18 @@ async def test_guard_dog_lock(hass: HomeAssistant) -> None:
     entity._handle_coordinator_update()
     assert entity.is_locked is False
 
-    # Call async_lock
+    # Call async_lock (should be no-op for wgv4haro)
+    device._send_datapoints.reset_mock()
     await entity.async_lock()
     await hass.async_block_till_done()
-    device._send_datapoints.assert_called_with([DPCode.MANUAL_LOCK])
-    assert device.datapoints[DPCode.MANUAL_LOCK].value is True
+    device._send_datapoints.assert_not_called()
 
-    # Call async_unlock
+    # Call async_unlock (should trigger DP 6 for wgv4haro)
+    device._send_datapoints.reset_mock()
     await entity.async_unlock()
     await hass.async_block_till_done()
-    device._send_datapoints.assert_called_with([DPCode.MANUAL_LOCK])
-    assert device.datapoints[DPCode.MANUAL_LOCK].value is False
+    device._send_datapoints.assert_called_with([6])
+    assert device.datapoints[6].value is True
 
     # Verify refined sensor mappings for wgv4haro
     from custom_components.tuya_ble.sensor import (


### PR DESCRIPTION
Fixes the mapping bug for the wgv4haro Guard Dog Security Smart Lock where locking was a no-op and unlocking should trigger DP 6. Updates the lock platform to use DP 6 for unlocking and no-op for locking for wgv4haro.

---
*PR created automatically by Jules for task [7074949549081312424](https://jules.google.com/task/7074949549081312424) started by @CloCkWeRX*