### PR TITLE
fix(device): Add MoistenLand Water Timer (8t5hebn0) mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ See a device marked Experimental you have? We could use real world testing feedb
       <td>Experimental.</td>
     </tr>
     <tr>
-      <td rowspan="8"><strong>Water valve controller</strong></td>
-      <td rowspan="8"><code>sfkzq</code></td>
+      <td rowspan="9"><strong>Water valve controller</strong></td>
+      <td rowspan="9"><code>sfkzq</code></td>
       <td>Water valve controller</td>
       <td><code>nxquc5lb</code></td>
       <td>—</td>
@@ -352,6 +352,11 @@ See a device marked Experimental you have? We could use real world testing feedb
     <tr>
       <td>Unistyle WT-04W Water Timer</td>
       <td><code>ojrvmfkk</code></td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td>MoistenLand Water Timer</td>
+      <td><code>8t5hebn0</code></td>
       <td>—</td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ See a device marked Experimental you have? We could use real world testing feedb
     <tr>
       <td>MoistenLand Water Timer</td>
       <td><code>8t5hebn0</code></td>
-      <td>—</td>
+      <td>Experimental</td>
     </tr>
     <tr>
       <td rowspan="5"><strong>Lights</strong></td>

--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -162,6 +162,26 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
     ),
     "sfkzq": TuyaBLECategoryBinarySensorMapping(
         products={
+            "8t5hebn0": [  # MoistenLand Water Timer
+                TuyaBLEBinarySensorMapping(
+                    dp_id=4,
+                    description=BinarySensorEntityDescription(
+                        key="fault",
+                        device_class=BinarySensorDeviceClass.PROBLEM,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                    getter=lambda sensor: setattr(
+                        sensor,
+                        "_attr_is_on",
+                        bool(
+                            _bitmap_value_to_int(sensor._device.datapoints[4].value)
+                            if sensor._device.datapoints[4]
+                            and sensor._device.datapoints[4].value is not None
+                            else False
+                        ),
+                    ),
+                ),
+            ],
             "ldcdnigc": [
                 TuyaBLEBinarySensorMapping(
                     dp_id=1,

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -678,6 +678,10 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             "tqzkwarw": TuyaBLEProductInfo(
                 name="HCT-611 Water Timer",
             ),
+            "8t5hebn0": TuyaBLEProductInfo(
+                name="MoistenLand Water Timer",
+                manufacturer="MoistenLand",
+            ),
         },
     ),
     "ggq": TuyaBLECategoryInfo(

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -249,6 +249,19 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     ),
                 ),
             ],
+            "8t5hebn0": [  # MoistenLand Water Timer
+                TuyaBLENumberMapping(
+                    dp_id=11,
+                    description=NumberEntityDescription(
+                        key="countdown",
+                        icon="mdi:timer",
+                        native_max_value=86400,
+                        native_min_value=0,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        native_step=1,
+                    ),
+                ),
+            ],
         },
     ),
     "dcb": TuyaBLECategoryNumberMapping(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -167,6 +167,22 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                     ),
                 ),
             ],
+            "8t5hebn0": [  # MoistenLand Water Timer
+                TuyaBLESelectMapping(
+                    dp_id=10,
+                    dp_type=TuyaBLEDataPointType.DT_STRING,
+                    description=SelectEntityDescription(
+                        key="weather_delay",
+                        options=[
+                            "cancel",
+                            "24h",
+                            "48h",
+                            "72h",
+                        ],
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+            ],
             "tqzkwarw": [  # HCT-611 Water Timer
                 TuyaBLESelectMapping(
                     dp_id=10,

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1511,6 +1511,29 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                 ),
                 TuyaBLEWorkStateMapping(dp_id=12),
             ],
+            "8t5hebn0": [  # MoistenLand Water Timer
+                TuyaBLEBatteryMapping(dp_id=7),
+                TuyaBLESensorMapping(
+                    dp_id=8,
+                    dp_type=TuyaBLEDataPointType.DT_STRING,
+                    description=SensorEntityDescription(
+                        key="battery_state",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=["low", "middle", "high"],
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLEWorkStateMapping(dp_id=12),
+                TuyaBLESensorMapping(
+                    dp_id=15,
+                    description=SensorEntityDescription(
+                        key="use_time_one",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+            ],
             "0axr5s0b": [  # Valve Controller
                 TuyaBLEBatteryMapping(dp_id=7),
                 TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -285,7 +285,12 @@
                 "name": "Moisture"
             },
             "work_state": {
-                "name": "Work state"
+                "name": "Work state",
+                "state": {
+                    "auto": "Auto",
+                    "manual": "Manual",
+                    "idle": "Idle"
+                }
             },
             "work_state_z1": {
                 "name": "Work state - Zone 1",

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -283,6 +283,16 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                 ),
                 TuyaBLEWaterValveWeatherSwitchMapping(dp_id=14),
             ],
+            "8t5hebn0": [  # MoistenLand Water Timer
+                TuyaBLESwitchMapping(
+                    dp_id=1,
+                    description=SwitchEntityDescription(
+                        key="water_valve",
+                        icon="mdi:valve",
+                        entity_registry_enabled_default=True,
+                    ),
+                ),
+            ],
             **dict.fromkeys(
                 ["nxquc5lb", "svhikeyq"],
                 [  # Smart water timer - SOP10

--- a/custom_components/tuya_ble/translations/de.json
+++ b/custom_components/tuya_ble/translations/de.json
@@ -255,7 +255,12 @@
                 "name": "Bodenfeuchtigkeit"
             },
             "work_state": {
-                "name": "Betriebszustand"
+                "name": "Betriebszustand",
+                "state": {
+                    "auto": "Auto",
+                    "manual": "Manuell",
+                    "idle": "Inaktiv"
+                }
             },
             "work_state_z1": {
                 "name": "Betriebszustand - Zone 1"

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -293,7 +293,12 @@
                 "name": "Moisture"
             },
             "work_state": {
-                "name": "Work state"
+                "name": "Work state",
+                "state": {
+                    "auto": "Auto",
+                    "manual": "Manual",
+                    "idle": "Idle"
+                }
             },
             "work_state_z1": {
                 "name": "Work state - Zone 1",

--- a/custom_components/tuya_ble/translations/es.json
+++ b/custom_components/tuya_ble/translations/es.json
@@ -255,7 +255,12 @@
                 "name": "Humedad de suelo"
             },
             "work_state": {
-                "name": "Estado de funcionamiento"
+                "name": "Estado de funcionamiento",
+                "state": {
+                    "auto": "Automático",
+                    "manual": "Manual",
+                    "idle": "Inactivo"
+                }
             },
             "work_state_z1": {
                 "name": "Estado de funcionamiento - Zona 1"

--- a/custom_components/tuya_ble/translations/fr.json
+++ b/custom_components/tuya_ble/translations/fr.json
@@ -255,7 +255,12 @@
                 "name": "Humidité du sol"
             },
             "work_state": {
-                "name": "État de fonctionnement"
+                "name": "État de fonctionnement",
+                "state": {
+                    "auto": "Auto",
+                    "manual": "Manuel",
+                    "idle": "Inactif"
+                }
             },
             "work_state_z1": {
                 "name": "État de fonctionnement - Zone 1"

--- a/custom_components/tuya_ble/translations/it.json
+++ b/custom_components/tuya_ble/translations/it.json
@@ -255,7 +255,12 @@
                 "name": "Umidità del terreno"
             },
             "work_state": {
-                "name": "Stato di funzionamento"
+                "name": "Stato di funzionamento",
+                "state": {
+                    "auto": "Automatico",
+                    "manual": "Manuale",
+                    "idle": "Inattivo"
+                }
             },
             "work_state_z1": {
                 "name": "Stato di funzionamento - Zona 1"

--- a/custom_components/tuya_ble/translations/pt-BR.json
+++ b/custom_components/tuya_ble/translations/pt-BR.json
@@ -255,7 +255,12 @@
                 "name": "Umidade do solo"
             },
             "work_state": {
-                "name": "Estado de funcionamento"
+                "name": "Estado de funcionamento",
+                "state": {
+                    "auto": "Automático",
+                    "manual": "Manual",
+                    "idle": "Inativo"
+                }
             },
             "work_state_z1": {
                 "name": "Estado de funcionamento - Zona 1"

--- a/custom_components/tuya_ble/translations/zh-Hans.json
+++ b/custom_components/tuya_ble/translations/zh-Hans.json
@@ -255,7 +255,12 @@
                 "name": "水分"
             },
             "work_state": {
-                "name": "工作状态"
+                "name": "工作状态",
+                "state": {
+                    "auto": "自动",
+                    "manual": "手动",
+                    "idle": "空闲"
+                }
             },
             "work_state_z1": {
                 "name": "工作状态 - 区域 1"


### PR DESCRIPTION
This PR implements local integration support for the MoistenLand Water Timer (device ID `8t5hebn0`) under the `sfkzq` category. All datapoints from the tuya-local configuration have been successfully translated to the ha_tuya_ble architecture, and all translation strings have been synchronized and updated accordingly. All existing tests pass.

---
*PR created automatically by Jules for task [4479311473984674338](https://jules.google.com/task/4479311473984674338) started by @CloCkWeRX*