### PR TITLE
fix(device): add support for Product Securosmart lock (uyf1ewof)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ See a device marked Experimental you have? We could use real world testing feedb
       <td>—</td>
     </tr>
     <tr>
-      <td rowspan="23"><strong>Smart Locks</strong></td>
-      <td rowspan="23"><code>ms</code>, <code>jtmspro</code></td>
+      <td rowspan="24"><strong>Smart Locks</strong></td>
+      <td rowspan="24"><code>ms</code>, <code>jtmspro</code></td>
       <td>Smart Lock</td>
       <td><code>ludzroix</code>, <code>isk2p555</code>, <code>gumrixyt</code>, <code>uamrw6h3</code>, <code>sidhzylo</code>, <code>mqc2hevy</code>, <code>7a4xvbtt</code></td>
       <td>—</td>
@@ -241,6 +241,11 @@ See a device marked Experimental you have? We could use real world testing feedb
     <tr>
       <td>XCase NX-4964 Lock Box</td>
       <td><code>qicggi0m</code></td>
+      <td>—</td>
+    </tr>
+    <tr>
+      <td>Example Product Securosmart lock</td>
+      <td><code>uyf1ewof</code></td>
       <td>—</td>
     </tr>
     <tr>

--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -244,6 +244,23 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
     ),
     "jtmspro": TuyaBLECategoryBinarySensorMapping(
         products={
+            "uyf1ewof": [
+                TuyaBLEBinarySensorMapping(
+                    dp_id=47,
+                    description=BinarySensorEntityDescription(
+                        key="lock_motor_state",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLEBinarySensorMapping(
+                    dp_id=22,
+                    description=BinarySensorEntityDescription(
+                        key="hijack",
+                        device_class=BinarySensorDeviceClass.TAMPER,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+            ],
             **dict.fromkeys(
                 [
                     "stugc8dl",

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -171,6 +171,14 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
     ),
     "jtmspro": TuyaBLECategoryButtonMapping(
         products={
+            "uyf1ewof": [
+                TuyaBLEButtonMapping(
+                    dp_id=6,
+                    description=ButtonEntityDescription(
+                        key="bluetooth_unlock",
+                    ),
+                ),
+            ],
             "hc7n0urm": [  # A1 Ultra-JM
                 TuyaBLEButtonMapping(
                     dp_id=71,  # BLE unlock check

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -446,6 +446,11 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
     ),
     "jtmspro": TuyaBLECategoryInfo(
         products={
+            "uyf1ewof": TuyaBLEProductInfo(
+                name="Securosmart lock",
+                manufacturer="Example Product",
+                lock=1,
+            ),
             "y2yaegze": TuyaBLEProductInfo(name="Drawer Lock CTL20H", lock=1),
             "hc7n0urm": TuyaBLEProductInfo(  # device product_id
                 name="A1 Ultra-JM",

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -399,6 +399,47 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
     ),
     "jtmspro": TuyaBLECategorySensorMapping(
         products={
+            "uyf1ewof": [
+                TuyaBLEAlarmLockStateMapping(dp_id=21),
+                TuyaBLESensorMapping(
+                    dp_id=12,  # Retrieve last fingerprint used
+                    description=SensorEntityDescription(
+                        key="unlock_fingerprint",
+                        icon="mdi:fingerprint",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=19,  # Retrieve last BLE used
+                    description=SensorEntityDescription(
+                        key="unlock_ble",
+                        icon="mdi:bluetooth",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=30,
+                    description=SensorEntityDescription(
+                        key="key_tone",
+                        icon="mdi:volume-high",
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=62,  # Retrieve last remote phone used
+                    description=SensorEntityDescription(
+                        key="unlock_phone_remote",
+                        icon="mdi:cellphone-lock",
+                        suggested_display_precision=0,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=63,  # Retrieve last voice unlock used
+                    description=SensorEntityDescription(
+                        key="unlock_voice",
+                        icon="mdi:microphone",
+                    ),
+                ),
+                TuyaBLEBatteryMapping(dp_id=8),
+            ],
             "y2yaegze": [
                 TuyaBLEAlarmLockStateMapping(dp_id=21),
                 TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -376,6 +376,9 @@
             "unlock_phone_remote": {
                 "name": "Last used remote phone"
             },
+            "key_tone": {
+                "name": "Key tone"
+            },
             "time_remaining": {
                 "name": "Time remaining"
             }

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -522,6 +522,23 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
     ),
     "jtmspro": TuyaBLECategorySwitchMapping(
         products={
+            "uyf1ewof": [
+                TuyaBLESwitchMapping(
+                    dp_id=33,
+                    description=SwitchEntityDescription(
+                        key="automatic_lock",
+                        icon="mdi:lock-clock",
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=46,
+                    description=SwitchEntityDescription(
+                        key="manual_lock",
+                        icon="mdi:lock-plus",
+                    ),
+                ),
+            ],
             "y2yaegze": [
                 TuyaBLESwitchMapping(
                     dp_id=33,

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -390,6 +390,9 @@
             "unlock_temp_pwd": {
                 "name": "Last used Temporary Password"
             },
+            "key_tone": {
+                "name": "Key tone"
+            },
             "time_remaining": {
                 "name": "Time remaining"
             }


### PR DESCRIPTION
Fix #135 

This PR adds support for the "Pirnar Securosmart" Door Lock - uyf1ewof.

This one is AI created.

Pls see the DP_IDs:
  ```
"result": {
    "properties": [
      {
        "code": "unlock_method_create",
        "custom_name": "",
        "dp_id": 1,
        "time": 1781449247423,
        "type": "raw",
        "value": "A/8BAQMAAA=="
      },
      {
        "code": "unlock_method_delete",
        "custom_name": "",
        "dp_id": 2,
        "time": 1769437955531,
        "type": "raw"
      },
      {
        "code": "unlock_method_modify",
        "custom_name": "",
        "dp_id": 3,
        "time": 1769437955531,
        "type": "raw"
      },
      {
        "code": "bluetooth_unlock",
        "custom_name": "",
        "dp_id": 6,
        "time": 1769584227748,
        "type": "raw",
        "value": "AQE="
      },
      {
        "code": "residual_electricity",
        "custom_name": "",
        "dp_id": 8,
        "time": 1769437955531,
        "type": "value",
        "value": -1
      },
      {
        "code": "unlock_fingerprint",
        "custom_name": "",
        "dp_id": 12,
        "time": 1783697804000,
        "type": "value",
        "value": 2
      },
      {
        "code": "unlock_ble",
        "custom_name": "",
        "dp_id": 19,
        "time": 1769584230000,
        "type": "value",
        "value": 1
      },
      {
        "code": "alarm_lock",
        "custom_name": "",
        "dp_id": 21,
        "time": 1783697794000,
        "type": "enum",
        "value": "wrong_face"
      },
      {
        "code": "hijack",
        "custom_name": "",
        "dp_id": 22,
        "time": 1769437955531,
        "type": "bool",
        "value": false
      },
      {
        "code": "key_tone",
        "custom_name": "",
        "dp_id": 30,
        "time": 1769437955531,
        "type": "enum",
        "value": "day"
      },
      {
        "code": "automatic_lock",
        "custom_name": "",
        "dp_id": 33,
        "time": 1784412973288,
        "type": "bool",
        "value": false
      },
      {
        "code": "rtc_lock",
        "custom_name": "",
        "dp_id": 44,
        "time": 1769437955531,
        "type": "bool",
        "value": false
      },
      {
        "code": "manual_lock",
        "custom_name": "",
        "dp_id": 46,
        "time": 1769515869796,
        "type": "bool",
        "value": true
      },
      {
        "code": "lock_motor_state",
        "custom_name": "",
        "dp_id": 47,
        "time": 1781449290741,
        "type": "bool",
        "value": false
      },
      {
        "code": "synch_method",
        "custom_name": "",
        "dp_id": 54,
        "time": 1781449192162,
        "type": "raw",
        "value": "AQE="
      },
      {
        "code": "remote_no_pd_setkey",
        "custom_name": "",
        "dp_id": 60,
        "time": 1769437959823,
        "type": "raw",
        "value": "AAAB"
      },
      {
        "code": "remote_no_dp_key",
        "custom_name": "",
        "dp_id": 61,
        "time": 1769439526767,
        "type": "raw",
        "value": "AAEA"
      },
      {
        "code": "unlock_phone_remote",
        "custom_name": "",
        "dp_id": 62,
        "time": 1769439526000,
        "type": "value",
        "value": 1
      },
      {
        "code": "unlock_voice_remote",
        "custom_name": "",
        "dp_id": 63,
        "time": 1769437955531,
        "type": "value",
        "value": 0
      },
      {
        "code": "record",
        "custom_name": "",
        "dp_id": 69,
        "time": 1769437955531,
        "type": "raw"
      }
    ]
```