### PR TITLE
fix(device): map Fingerbot Plus 6jcvqwh0 in the kg category

### DIFF
--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -150,7 +150,13 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
     "kg": TuyaBLECategoryButtonMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
+                [
+                    "mknd4lci",
+                    "riecov42",
+                    "bs3ubslo",
+                    "gnpbj0bq",
+                    "6jcvqwh0"
+                ],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotModeMapping(dp_id=108),
                 ],

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -155,7 +155,7 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
                     "riecov42",
                     "bs3ubslo",
                     "gnpbj0bq",
-                    "6jcvqwh0"
+                    "6jcvqwh0",
                 ],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotModeMapping(dp_id=108),

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -150,7 +150,7 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
     "kg": TuyaBLECategoryButtonMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotModeMapping(dp_id=108),
                 ],

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -562,7 +562,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
     "kg": TuyaBLECategoryInfo(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq"],  # device product_ids
+                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # device product_ids
                 TuyaBLEProductInfo(
                     name="Fingerbot Plus",
                     fingerbot=TuyaBLEFingerbotInfo(

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -562,7 +562,13 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
     "kg": TuyaBLECategoryInfo(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # device product_ids
+                [
+                    "mknd4lci",
+                    "riecov42",
+                    "bs3ubslo",
+                    "gnpbj0bq",
+                    "6jcvqwh0",
+                ],  # device product_ids
                 TuyaBLEProductInfo(
                     name="Fingerbot Plus",
                     fingerbot=TuyaBLEFingerbotInfo(

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -505,7 +505,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
     "kg": TuyaBLECategoryNumberMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLENumberMapping(
                         dp_id=102,

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -505,7 +505,13 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
     "kg": TuyaBLECategoryNumberMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
+                [
+                    "mknd4lci",
+                    "riecov42",
+                    "bs3ubslo",
+                    "gnpbj0bq",
+                    "6jcvqwh0"
+                ],  # Fingerbot Plus
                 [
                     TuyaBLENumberMapping(
                         dp_id=102,

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -510,7 +510,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     "riecov42",
                     "bs3ubslo",
                     "gnpbj0bq",
-                    "6jcvqwh0"
+                    "6jcvqwh0",
                 ],  # Fingerbot Plus
                 [
                     TuyaBLENumberMapping(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -676,7 +676,13 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
     "kg": TuyaBLECategorySelectMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
+                [
+                    "mknd4lci",
+                    "riecov42",
+                    "bs3ubslo",
+                    "gnpbj0bq",
+                    "6jcvqwh0",
+                ],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotModeMapping(dp_id=101),
                 ],

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -676,7 +676,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
     "kg": TuyaBLECategorySelectMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotModeMapping(dp_id=101),
                 ],

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -777,7 +777,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
     "kg": TuyaBLECategorySensorMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "gnpbj0bq"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLEBatteryMapping(dp_id=105),
                 ],

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -625,7 +625,7 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
     "kg": TuyaBLECategorySwitchMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotSwitchMapping(dp_id=1),
                     TuyaBLEReversePositionsMapping(dp_id=104),

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -625,7 +625,13 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
     "kg": TuyaBLECategorySwitchMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
+                [
+                    "mknd4lci",
+                    "riecov42",
+                    "bs3ubslo",
+                    "gnpbj0bq",
+                    "6jcvqwh0",
+                ],  # Fingerbot Plus
                 [
                     TuyaBLEFingerbotSwitchMapping(dp_id=1),
                     TuyaBLEReversePositionsMapping(dp_id=104),

--- a/custom_components/tuya_ble/text.py
+++ b/custom_components/tuya_ble/text.py
@@ -167,7 +167,7 @@ mapping: dict[str, TuyaBLECategoryTextMapping] = {
     "kg": TuyaBLECategoryTextMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq"],  # Fingerbot Plus
+                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
                 [
                     TuyaBLETextMapping(
                         dp_id=109,

--- a/custom_components/tuya_ble/text.py
+++ b/custom_components/tuya_ble/text.py
@@ -167,7 +167,13 @@ mapping: dict[str, TuyaBLECategoryTextMapping] = {
     "kg": TuyaBLECategoryTextMapping(
         products={
             **dict.fromkeys(
-                ["mknd4lci", "riecov42", "bs3ubslo", "gnpbj0bq", "6jcvqwh0"],  # Fingerbot Plus
+                [
+                    "mknd4lci",
+                    "riecov42",
+                    "bs3ubslo",
+                    "gnpbj0bq",
+                    "6jcvqwh0",
+                ],  # Fingerbot Plus
                 [
                     TuyaBLETextMapping(
                         dp_id=109,


### PR DESCRIPTION
The README already lists 6jcvqwh0 as a supported Fingerbot Plus, but the mapping only exists under the szjqr category. Tuya hands some of these units out as category kg, and the lookup is keyed on (category, product_id), so those devices match nothing: only generic entities are created and commands go to the szjqr datapoints (switch=2, mode=8, up=15, down=9, hold=10).

That failure is quiet. Tuya BLE acknowledges writes to datapoints the device does not implement, so Home Assistant shows result: 0 and logs a state change while the arm never moves. Mode and Program stay unknown, and picking a Mode value sends no packet at all.

The real datapoints on a kg unit were read back from the device itself, by enabling debug logging and pressing the physical button so it reports unprompted: switch=1, mode=101, up=106, down=102, hold=103, manual=107, program=109, battery=105 -- which is exactly the layout the kg section already describes. Adding the product id to the kg lists is enough.

Verified on an Adaprox Fingerbot Plus, BLE DC:23:52:CC:A7:2E, reported by the Tuya cloud as category kg / product_id 6jcvqwh0.