### PR TITLE
fix(protocol): release a connection that dropped unexpectedly

### DIFF
--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -694,9 +694,7 @@ class TuyaBLEDevice:
         elif dropped_client is not None:
             asyncio.create_task(self._release_client(dropped_client))
 
-    async def _release_client(
-        self, client: BleakClientWithServiceCache | None
-    ) -> None:
+    async def _release_client(self, client: BleakClientWithServiceCache | None) -> None:
         """Let go of a connection that dropped on us.
 
         bleak routes notifications through a per-device watcher registered on

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -677,6 +677,7 @@ class TuyaBLEDevice:
             )
             self._fire_disconnected_callbacks()
             return
+        dropped_client = self._client
         self._client = None
         _LOGGER.warning(
             "%s: Device unexpectedly disconnected; RSSI: %s",
@@ -689,7 +690,54 @@ class TuyaBLEDevice:
                 self.address,
                 self.rssi,
             )
-            asyncio.create_task(self._reconnect())
+            asyncio.create_task(self._release_and_reconnect(dropped_client))
+        elif dropped_client is not None:
+            asyncio.create_task(self._release_client(dropped_client))
+
+    async def _release_client(
+        self, client: BleakClientWithServiceCache | None
+    ) -> None:
+        """Let go of a connection that dropped on us.
+
+        bleak routes notifications through a per-device watcher registered on
+        the shared BlueZ manager at connect time, and only removes it when the
+        client is disconnected. A planned disconnect goes through
+        _execute_disconnect() and cleans up; an unexpected one used to just drop
+        our reference, leaving the watcher registered forever.
+
+        Every reconnect then added another watcher, and each of them delivers
+        every notification to the callback the newest connection registered. So
+        after n connections the parser sees each packet n times, which breaks
+        reassembly: it waits for packet n+1 while copies of packet n arrive,
+        _clean_input() discards the partial response and then takes a copy as
+        the start of a fresh one. Past a handful of reconnects nothing is ever
+        assembled -- the device still shows as connected, commands are accepted
+        and silently do nothing, and only a restart clears it. See #170.
+        """
+        if client is None:
+            return
+        try:
+            await client.disconnect()
+        except Exception:  # noqa: BLE001 - the link is already gone
+            _LOGGER.debug(
+                "%s: Releasing the dropped connection failed",
+                self.address,
+                exc_info=True,
+            )
+
+    async def _release_and_reconnect(
+        self, client: BleakClientWithServiceCache | None
+    ) -> None:
+        """Release the dropped connection, then reconnect.
+
+        Ordered deliberately: the watcher has to go before a new connection
+        registers its own, and doing both in one task is what guarantees it.
+        Releasing is safe at this point precisely because the old link is
+        already down and the new one does not exist yet -- BlueZ's Disconnect
+        acts on the device, so there is nothing here for it to disturb.
+        """
+        await self._release_client(client)
+        await self._reconnect()
 
     def _disconnect(self) -> None:
         """Disconnect from device."""

--- a/tests/test_dropped_connection_release.py
+++ b/tests/test_dropped_connection_release.py
@@ -1,0 +1,116 @@
+"""Tests for releasing a connection that dropped unexpectedly."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+from custom_components.tuya_ble.const import DOMAIN
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDevice
+
+CONFIG = {
+    "1234": {
+        "address": "11:22:33:44:55:66",
+        "device_id": "767823809c9c1f458745",
+        "protocol_version": "3.3",
+        "local_key": "wV[NcWGUSFF`dSgO",
+        "friendly_name": "Local 3G",
+    }
+}
+
+
+async def _make_device(hass: HomeAssistant) -> TuyaBLEDevice:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": "11:22:33:44:55:66",
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33:44:55:66", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    return device
+
+
+async def test_unexpected_disconnect_releases_the_dropped_client(
+    hass: HomeAssistant,
+) -> None:
+    """A connection that drops on us has to be released, not just forgotten.
+
+    bleak removes its per-device notification watcher when the client is
+    disconnected. Forgetting the client leaves the watcher registered, the next
+    connection adds another, and every notification is then delivered once per
+    watcher.
+    """
+    device = await _make_device(hass)
+    dropped = Mock()
+    dropped.disconnect = AsyncMock()
+    device._client = dropped
+    device._is_paired = True
+    device._expected_disconnect = False
+
+    with patch.object(device, "_reconnect", AsyncMock()):
+        device._disconnected(dropped)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    dropped.disconnect.assert_awaited_once()
+
+
+async def test_dropped_client_is_released_before_reconnecting(
+    hass: HomeAssistant,
+) -> None:
+    """Order matters: the old watcher must go before a new one is registered."""
+    device = await _make_device(hass)
+    dropped = Mock()
+    calls: list[str] = []
+
+    async def _disconnect() -> None:
+        calls.append("release")
+
+    async def _reconnect() -> None:
+        calls.append("reconnect")
+
+    dropped.disconnect = _disconnect
+
+    with patch.object(device, "_reconnect", _reconnect):
+        await device._release_and_reconnect(dropped)
+
+    assert calls == ["release", "reconnect"]
+
+
+async def test_release_survives_a_failing_disconnect(hass: HomeAssistant) -> None:
+    """The link is already gone, so a failing disconnect must not stop us."""
+    device = await _make_device(hass)
+    dropped = Mock()
+    dropped.disconnect = AsyncMock(side_effect=BleakError("not connected"))
+
+    await device._release_client(dropped)
+
+    dropped.disconnect.assert_awaited_once()
+
+
+async def test_planned_disconnect_does_not_release_again(
+    hass: HomeAssistant,
+) -> None:
+    """_execute_disconnect() already cleans up; do not double up on its path."""
+    device = await _make_device(hass)
+    client = Mock()
+    client.disconnect = AsyncMock()
+    device._client = client
+    device._expected_disconnect = True
+
+    device._disconnected(client)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    client.disconnect.assert_not_awaited()


### PR DESCRIPTION
bleak routes notifications through a per-device watcher it registers on the shared BlueZ manager at connect time, and removes only when the client is disconnected. A planned disconnect goes through _execute_disconnect(), which calls disconnect() and cleans up. An unexpected one went through _disconnected(), which just dropped our reference to the client -- so that watcher stayed registered forever.

Every reconnect then added one more watcher, and all of them deliver each notification to the callback the newest connection registered. After n connections the parser sees every packet n times.

The duplicates break reassembly rather than merely being noisy. The parser waits for packet n+1 while a copy of packet n arrives, _clean_input() discards the partial response and then takes that copy as the start of a fresh one, so the exchange restarts -- forever. Past a handful of reconnects nothing is ever assembled: the device still shows as connected, commands are accepted and silently do nothing, and the log fills with "Missing packet ... received N" / "Unexpected packet ... expected N". Only a restart clears it, because that is what finally drops the accumulated watchers.

Measured on an Adaprox Fingerbot Plus with debug logging on, by tagging each delivery with the identity of the handler, its client and the subscription that registered it. Every copy of a packet arrived at the same handler, from the same client, on the current subscription, one millisecond apart -- and the number of copies equalled the number of connections since startup: 2 after two, 3 after three, ~35 after four days of uptime, 1 right after a restart. Guards that drop notifications from a superseded client or subscription were tried first and never fired once: the deliveries are indistinguishable by anything reachable from the callback, because they all end up in the newest one. This matches #170, reported on a different Fingerbot.

Releasing the dropped client is what removes its watcher, and doing it in the same task as the reconnect is what guarantees the old one is gone before the new connection registers its own. It is safe here precisely because the old link is already down and the new one does not exist yet: BlueZ's Disconnect acts on the device, so at this point there is nothing for it to disturb.