### PR TITLE
fix: add raw bluetooth unlock support for LA-01 (oyqux5vv)

### DIFF
--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -193,7 +193,6 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
                     "stugc8dl",  # HU06 Smart Lock
                     "xicdxood",  # Raycube K7 Pro+
                     "rlyxv7pe",  # A1 PRO MAX
-                    "oyqux5vv",  # LA-01
                 ],
                 [
                     # Raycube K7 Pro+, unclear if applicable to A1 PRO MAX
@@ -207,6 +206,16 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
                     ),
                 ],
             ),
+            "oyqux5vv": [  # LA-01 Smart lock
+                TuyaBLEButtonMapping(
+                    dp_id=71,
+                    description=ButtonEntityDescription(
+                        key="bluetooth_unlock",
+                        icon="mdi:lock-open-variant-outline",
+                    ),
+                    dp_type=TuyaBLEDataPointType.DT_RAW,
+                ),
+            ],
             "hs21i377": [  # Raycube K7 Pro+
                 TuyaBLEButtonMapping(
                     dp_id=71,
@@ -301,8 +310,8 @@ class TuyaBLEButton(TuyaBLEEntity, ButtonEntity):
         self._mapping = mapping
 
     async def _run_hs21i377_unlock(self) -> None:
-        """Run the validated dp71 unlock flow for hs21i377."""
-        # hs21i377 uses a device-specific dp71 unlock payload.
+        """Run the validated dp71 unlock flow for hs21i377 and oyqux5vv."""
+        # hs21i377 and oyqux5vv (LA-01) use a device-specific dp71 unlock payload.
         # Practical testing confirmed multiple payload variants can unlock,
         # so this is not treated as a fixed "known lock code". We keep an
         # empirically validated value here until the payload semantics are
@@ -337,7 +346,7 @@ class TuyaBLEButton(TuyaBLEEntity, ButtonEntity):
             if self._mapping.description.key == "bluetooth_unlock":
                 self._hass.create_task(self._run_kholoaew_unlock())
                 return
-        if self._device.product_id == "hs21i377":
+        if self._device.product_id in ("hs21i377", "oyqux5vv"):
             if self._mapping.description.key == "bluetooth_unlock":
                 self._hass.create_task(self._run_hs21i377_unlock())
                 return

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -20,7 +20,7 @@ CONFIG = {
                 "id": "71",
                 "platform": "button",
                 "restore_on_reconnect": False,
-                "address": "12:23:44"
+                "address": "12:23:44",
             }
         ],
     }
@@ -32,7 +32,12 @@ async def test_button(hass: HomeAssistant) -> None:
     from pytest_homeassistant_custom_component.common import MockConfigEntry
     from custom_components.tuya_ble.const import DOMAIN
     from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
-    from custom_components.tuya_ble.devices import TuyaBLEDevice, TuyaBLEProductInfo, TuyaBLECoordinator, TuyaBLEData
+    from custom_components.tuya_ble.devices import (
+        TuyaBLEDevice,
+        TuyaBLEProductInfo,
+        TuyaBLECoordinator,
+        TuyaBLEData,
+    )
     from bleak.backends.device import BLEDevice
 
     entry = MockConfigEntry(
@@ -74,9 +79,7 @@ async def test_button(hass: HomeAssistant) -> None:
         ),
         force_add=True,
     )
-    entity = TuyaBLEButton(
-        hass, coordinator, device, product_info, mapping
-    )
+    entity = TuyaBLEButton(hass, coordinator, device, product_info, mapping)
     entity.async_write_ha_state = Mock()
 
     assert entity.available is False
@@ -95,3 +98,91 @@ async def test_button(hass: HomeAssistant) -> None:
     dp = device.datapoints[71]
     assert dp is not None
     assert dp.value is True
+
+
+async def test_oyqux5vv_raw_unlock(hass: HomeAssistant) -> None:
+    """Test raw bluetooth unlock button for LA-01 (oyqux5vv)."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.tuya_ble.const import DOMAIN
+    from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+    from custom_components.tuya_ble.devices import (
+        TuyaBLEDevice,
+        TuyaBLEProductInfo,
+        TuyaBLECoordinator,
+        TuyaBLEData,
+    )
+    from bleak.backends.device import BLEDevice
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "devices": CONFIG,
+            "address": DEVICE_ADDRESS,
+        },
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = BLEDevice(name="bob", address="11:22:33", details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    # Explicitly set product_id to oyqux5vv in device_info so button platform uses it
+    from custom_components.tuya_ble.tuya_ble.manager import TuyaBLEDeviceCredentials
+
+    device._device_info = TuyaBLEDeviceCredentials(
+        uuid="uuid123",
+        local_key="wV[NcWGUSFF`dSgO",
+        device_id="767823809c9c1f458745",
+        category="jtmspro",
+        product_id="oyqux5vv",
+        device_name="LA-01",
+        product_model="LA-01",
+        product_name="LA-01",
+        functions=[],
+        status_range=[],
+    )
+    product_info = TuyaBLEProductInfo("LA-01 Smart lock", lock=1)
+
+    device._send_datapoints = AsyncMock()
+
+    hass.data.setdefault(DOMAIN, {})
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    tuya_ble_hass_data = TuyaBLEData(
+        title="Hello",
+        device=device,
+        manager=manager,
+        product=product_info,
+        coordinator=coordinator,
+    )
+    hass.data[DOMAIN][entry.entry_id] = tuya_ble_hass_data
+
+    # Map the button mapping for oyqux5vv
+    mapping = TuyaBLEButtonMapping(
+        dp_id=71,
+        description=ButtonEntityDescription(
+            key="bluetooth_unlock",
+            name="Unlock",
+        ),
+        dp_type=TuyaBLEDataPointType.DT_RAW,
+        force_add=True,
+    )
+    entity = TuyaBLEButton(hass, coordinator, device, product_info, mapping)
+    entity.async_write_ha_state = Mock()
+
+    coordinator._async_handle_connect()
+    assert entity.available is True
+
+    # Press the button
+    entity.press()
+    await hass.async_block_till_done()
+
+    # Verify _send_datapoints was called with DP 71
+    device._send_datapoints.assert_called_once_with([71])
+
+    # DP 71 was created as DT_RAW and should contain the validated bytes payload
+    dp = device.datapoints[71]
+    assert dp is not None
+    assert dp.type == TuyaBLEDataPointType.DT_RAW
+    assert dp.value == bytes.fromhex("0001ffff36383538313536320169ab34cd0000")


### PR DESCRIPTION
This pull request adds support for the RAW bluetooth unlock button on the LA-01 smart lock (product ID oyqux5vv, category jtmspro) on DP 71.
The button sends the validated raw payload '0001ffff36383538313536320169ab34cd0000' to unlock the lock.
A new test is added in tests/test_button.py to verify correct behavior.
This PR closes #278.

---
*PR created automatically by Jules for task [6322196782239603449](https://jules.google.com/task/6322196782239603449) started by @CloCkWeRX*