### PR TITLE
fix: correct category for window cleaner robot (cxjmb → ccjqr)

### DIFF
--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -370,7 +370,7 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
     #         ],
     #     }
     # ),
-    "cxjmb": TuyaBLECategoryBinarySensorMapping(
+    "ccjqr": TuyaBLECategoryBinarySensorMapping(
         products={
             "pnxl0r3l": [  # Window Cleaner Robot - fault bitmap (DP11)
                 TuyaBLEBinarySensorMapping(

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -745,7 +745,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             "v3fzfd2y": TuyaBLEProductInfo(name="AOK AM25 Roller Blinds Motor"),
         }
     ),
-    "cxjmb": TuyaBLECategoryInfo(
+    "ccjqr": TuyaBLECategoryInfo(
         products={
             "pnxl0r3l": TuyaBLEProductInfo(
                 name="Window Cleaner Robot",

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -723,7 +723,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
             ],
         },
     ),
-    "cxjmb": TuyaBLECategorySelectMapping(
+    "ccjqr": TuyaBLECategorySelectMapping(
         products={
             "pnxl0r3l": [  # Window Cleaner Robot
                 TuyaBLESelectMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1742,7 +1742,7 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
             ),
         }
     ),
-    "cxjmb": TuyaBLECategorySensorMapping(
+    "ccjqr": TuyaBLECategorySensorMapping(
         products={
             "pnxl0r3l": [  # Window Cleaner Robot
                 TuyaBLESensorMapping(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -859,7 +859,7 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
             ),
         },
     ),
-    "cxjmb": TuyaBLECategorySwitchMapping(
+    "ccjqr": TuyaBLECategorySwitchMapping(
         products={
             "pnxl0r3l": [  # Window Cleaner Robot
                 TuyaBLESwitchMapping(

--- a/custom_components/tuya_ble/vacuum.py
+++ b/custom_components/tuya_ble/vacuum.py
@@ -163,7 +163,7 @@ class TuyaBLECategoryVacuumMapping:
 # ---------------------------------------------------------------------------
 
 mapping: dict[str, TuyaBLECategoryVacuumMapping] = {
-    "cxjmb": TuyaBLECategoryVacuumMapping(
+    "ccjqr": TuyaBLECategoryVacuumMapping(
         products={
             "pnxl0r3l": TuyaBLEVacuumMapping(  # CHYW200.ABIR
                 dp_start_bool=1,  # switch_go (bool)


### PR DESCRIPTION
Follow-up to #159 

The window cleaner robot (product_id `pnxl0r3l`) was mapped under the wrong Tuya category (`cxjmb`) when it was originally added. This PR corrects it to `ccjqr`, which is the actual category for this device, across all affected mappings: vacuum, devices, switch, select, binary_sensor, and sensor.

Since the fallback-by-product_id lookup has been dropped in favor of fixing categories directly at the source, this corrects the category itself rather than relying on any workaround.

Sorry for the delay getting this fixed — I've been short on time lately.