### PR TITLE
feat: add support for Parkside 4Ah and 12Ah batteries

### DIFF
--- a/custom_components/tuya_ble/binary_sensor.py
+++ b/custom_components/tuya_ble/binary_sensor.py
@@ -83,6 +83,8 @@ mapping: dict[str, TuyaBLECategoryBinarySensorMapping] = {
                 [
                     "ajrhf1aj",
                     "z5ztlw3k",
+                    "vllfabvs",
+                    "fay1puxy",
                 ],  # PARKSIDE Smart battery
                 [
                     TuyaBLEBinarySensorMapping(

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -85,7 +85,12 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
     "dcb": TuyaBLECategoryButtonMapping(
         products={
             **dict.fromkeys(
-                ["ajrhf1aj", "z5ztlw3k", "vllfabvs", "fay1puxy"],  # PARKSIDE Smart battery
+                [
+                    "ajrhf1aj",
+                    "z5ztlw3k",
+                    "vllfabvs",
+                    "fay1puxy"
+                ],  # PARKSIDE Smart battery
                 [
                     TuyaBLEButtonMapping(
                         dp_id=115,

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -89,7 +89,7 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
                     "ajrhf1aj",
                     "z5ztlw3k",
                     "vllfabvs",
-                    "fay1puxy"
+                    "fay1puxy",
                 ],  # PARKSIDE Smart battery
                 [
                     TuyaBLEButtonMapping(

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -85,7 +85,7 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
     "dcb": TuyaBLECategoryButtonMapping(
         products={
             **dict.fromkeys(
-                ["ajrhf1aj", "z5ztlw3k"],  # PARKSIDE Smart battery
+                ["ajrhf1aj", "z5ztlw3k", "vllfabvs", "fay1puxy"],  # PARKSIDE Smart battery
                 [
                     TuyaBLEButtonMapping(
                         dp_id=115,

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -436,6 +436,12 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
     "dcb": TuyaBLECategoryInfo(
         products={
             **dict.fromkeys(
+                ["vllfabvs"],
+                TuyaBLEProductInfo(  # device product_id
+                    name="PARKSIDE Smart battery 4Ah",
+                ),
+            ),
+            **dict.fromkeys(
                 ["z5ztlw3k"],
                 TuyaBLEProductInfo(  # device product_id
                     name="PARKSIDE Smart battery 4Ah",
@@ -445,6 +451,12 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                 ["ajrhf1aj"],
                 TuyaBLEProductInfo(  # device product_id
                     name="PARKSIDE Smart battery 8Ah",
+                ),
+            ),
+            **dict.fromkeys(
+                ["fay1puxy"],
+                TuyaBLEProductInfo(  # device product_id
+                    name="PARKSIDE Smart battery 12Ah",
                 ),
             ),
         },

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -267,7 +267,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
     "dcb": TuyaBLECategoryNumberMapping(
         products={
             **dict.fromkeys(
-                ["ajrhf1aj", "z5ztlw3k"],  # PARKSIDE Smart battery
+                ["ajrhf1aj", "z5ztlw3k", "vllfabvs", "fay1puxy"],  # PARKSIDE Smart battery
                 [
                     TuyaBLENumberMapping(
                         dp_id=116,

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -267,7 +267,12 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
     "dcb": TuyaBLECategoryNumberMapping(
         products={
             **dict.fromkeys(
-                ["ajrhf1aj", "z5ztlw3k", "vllfabvs", "fay1puxy"],  # PARKSIDE Smart battery
+                [
+                    "ajrhf1aj",
+                    "z5ztlw3k",
+                    "vllfabvs",
+                    "fay1puxy"
+                ],  # PARKSIDE Smart battery
                 [
                     TuyaBLENumberMapping(
                         dp_id=116,

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -271,7 +271,7 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     "ajrhf1aj",
                     "z5ztlw3k",
                     "vllfabvs",
-                    "fay1puxy"
+                    "fay1puxy",
                 ],  # PARKSIDE Smart battery
                 [
                     TuyaBLENumberMapping(

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -336,7 +336,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
     "dcb": TuyaBLECategorySelectMapping(
         products={
             **dict.fromkeys(
-                ["ajrhf1aj", "z5ztlw3k"],  # PARKSIDE Smart battery
+                ["ajrhf1aj", "z5ztlw3k", "vllfabvs", "fay1puxy"],  # PARKSIDE Smart battery
                 [
                     TuyaBLESelectMapping(
                         dp_id=105,

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -336,7 +336,12 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
     "dcb": TuyaBLECategorySelectMapping(
         products={
             **dict.fromkeys(
-                ["ajrhf1aj", "z5ztlw3k", "vllfabvs", "fay1puxy"],  # PARKSIDE Smart battery
+                [
+                    "ajrhf1aj",
+                    "z5ztlw3k",
+                    "vllfabvs",
+                    "fay1puxy"
+                ],  # PARKSIDE Smart battery
                 [
                     TuyaBLESelectMapping(
                         dp_id=105,

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -340,7 +340,7 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                     "ajrhf1aj",
                     "z5ztlw3k",
                     "vllfabvs",
-                    "fay1puxy"
+                    "fay1puxy",
                 ],  # PARKSIDE Smart battery
                 [
                     TuyaBLESelectMapping(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1608,7 +1608,6 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
             ],
         },
     ),
-
     "zwjcy": TuyaBLECategorySensorMapping(
         products={
             **dict.fromkeys(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -1028,9 +1028,10 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
         products={
             **dict.fromkeys(
                 [
+                    "vllfabvs",
                     "z5ztlw3k",
-                    "ajrhf1aj",
-                ],  # PARKSIDE Smart battery
+                    "fay1puxy",
+                ],  # PARKSIDE Smart battery 4Ah
                 [
                     TuyaBLEBatteryMapping(dp_id=16),
                     TuyaBLETemperatureMapping(dp_id=11),
@@ -1049,11 +1050,11 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                             key="battery_status",
                             device_class=SensorDeviceClass.ENUM,
                             options=[
-                                "Ready",
                                 "Charging",
+                                "Ready",
+                                "Sleep",
                                 "Discharging",
                                 "Full",
-                                "Sleep",
                                 "Error",
                             ],
                         ),
@@ -1065,7 +1066,6 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                             device_class=SensorDeviceClass.CURRENT,
                             native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE,
                             state_class=SensorStateClass.MEASUREMENT,
-                            entity_category=EntityCategory.DIAGNOSTIC,
                         ),
                     ),
                     TuyaBLESensorMapping(
@@ -1075,11 +1075,11 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                             device_class=SensorDeviceClass.VOLTAGE,
                             native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
                             state_class=SensorStateClass.MEASUREMENT,
-                            entity_category=EntityCategory.DIAGNOSTIC,
                         ),
                     ),
                     TuyaBLESensorMapping(
                         dp_id=101,
+                        coefficient=0.001,
                         description=SensorEntityDescription(
                             key="discharging_current",
                             device_class=SensorDeviceClass.CURRENT,
@@ -1319,8 +1319,296 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     ),
                 ],
             ),
+            "ajrhf1aj": [  # PARKSIDE Smart battery 8Ah
+                TuyaBLEBatteryMapping(dp_id=16),
+                TuyaBLETemperatureMapping(dp_id=11),
+                TuyaBLESensorMapping(
+                    dp_id=172,
+                    description=SensorEntityDescription(
+                        key="battery_temp_current",
+                        device_class=SensorDeviceClass.TEMPERATURE,
+                        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=102,
+                    description=SensorEntityDescription(
+                        key="battery_status",
+                        device_class=SensorDeviceClass.ENUM,
+                        options=[
+                            "Charging",
+                            "Ready",
+                            "Sleep",
+                            "Discharging",
+                            "Full",
+                            "Error",
+                        ],
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=2,
+                    description=SensorEntityDescription(
+                        key="charge_current",
+                        device_class=SensorDeviceClass.CURRENT,
+                        native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=3,
+                    coefficient=122.6,
+                    description=SensorEntityDescription(
+                        key="charge_voltage",
+                        device_class=SensorDeviceClass.VOLTAGE,
+                        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=101,
+                    coefficient=0.001,
+                    description=SensorEntityDescription(
+                        key="discharging_current",
+                        device_class=SensorDeviceClass.CURRENT,
+                        native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=103,
+                    description=SensorEntityDescription(
+                        key="charge_to_full_time",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=104,
+                    description=SensorEntityDescription(
+                        key="discharge_to_empty_time",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=8,
+                    description=SensorEntityDescription(
+                        key="charge_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=9,
+                    description=SensorEntityDescription(
+                        key="discharge_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=14,
+                    description=SensorEntityDescription(
+                        key="use_time",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=15,
+                    description=SensorEntityDescription(
+                        key="runtime_total",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=10,
+                    description=SensorEntityDescription(
+                        key="peak_current_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=21,
+                    description=SensorEntityDescription(
+                        key="fault",
+                        icon="mdi:alert-circle-outline",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=107,
+                    description=SensorEntityDescription(
+                        key="over_voltage_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=108,
+                    description=SensorEntityDescription(
+                        key="under_voltage_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=109,
+                    description=SensorEntityDescription(
+                        key="overtemp_discharge_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=110,
+                    description=SensorEntityDescription(
+                        key="overtemp_charge_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=111,
+                    description=SensorEntityDescription(
+                        key="undertemp_discharge_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=112,
+                    description=SensorEntityDescription(
+                        key="undertemp_charge_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=113,
+                    description=SensorEntityDescription(
+                        key="short_circuit_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=114,
+                    description=SensorEntityDescription(
+                        key="over_current_times",
+                        icon="mdi:counter",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=19,
+                    description=SensorEntityDescription(
+                        key="product_type",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=150,
+                    description=SensorEntityDescription(
+                        key="tool_product_type",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=152,
+                    description=SensorEntityDescription(
+                        key="tool_rotation_speed",
+                        icon="mdi:rotate-3d-variant",
+                        state_class=SensorStateClass.MEASUREMENT,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=153,
+                    description=SensorEntityDescription(
+                        key="tool_torque",
+                        icon="mdi:screw-lag",
+                        state_class=SensorStateClass.MEASUREMENT,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=154,
+                    description=SensorEntityDescription(
+                        key="tool_runtime_total",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.MINUTES,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=156,
+                    description=SensorEntityDescription(
+                        key="tool_fault",
+                        icon="mdi:alert-circle-outline",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=157,
+                    description=SensorEntityDescription(
+                        key="tools_current",
+                        device_class=SensorDeviceClass.CURRENT,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=158,
+                    description=SensorEntityDescription(
+                        key="tool_ot_times",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=159,
+                    description=SensorEntityDescription(
+                        key="tool_locked_times",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=160,
+                    description=SensorEntityDescription(
+                        key="tool_oc_times",
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                ),
+            ],
         },
     ),
+
     "zwjcy": TuyaBLECategorySensorMapping(
         products={
             **dict.fromkeys(

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -796,6 +796,8 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                 [
                     "ajrhf1aj",
                     "z5ztlw3k",
+                    "vllfabvs",
+                    "fay1puxy",
                 ],
                 [  # PARKSIDE Smart battery
                     TuyaBLESwitchMapping(

--- a/custom_components/tuya_ble/text.py
+++ b/custom_components/tuya_ble/text.py
@@ -148,7 +148,12 @@ mapping: dict[str, TuyaBLECategoryTextMapping] = {
     "dcb": TuyaBLECategoryTextMapping(
         products={
             **dict.fromkeys(
-                ["ajrhf1aj", "z5ztlw3k", "vllfabvs", "fay1puxy"],  # PARKSIDE Smart battery
+                [
+                    "ajrhf1aj",
+                    "z5ztlw3k",
+                    "vllfabvs", 
+                    "fay1puxy",
+                ],  # PARKSIDE Smart battery
                 [
                     TuyaBLETextMapping(
                         dp_id=106,

--- a/custom_components/tuya_ble/text.py
+++ b/custom_components/tuya_ble/text.py
@@ -151,7 +151,7 @@ mapping: dict[str, TuyaBLECategoryTextMapping] = {
                 [
                     "ajrhf1aj",
                     "z5ztlw3k",
-                    "vllfabvs", 
+                    "vllfabvs",
                     "fay1puxy",
                 ],  # PARKSIDE Smart battery
                 [

--- a/custom_components/tuya_ble/text.py
+++ b/custom_components/tuya_ble/text.py
@@ -148,7 +148,7 @@ mapping: dict[str, TuyaBLECategoryTextMapping] = {
     "dcb": TuyaBLECategoryTextMapping(
         products={
             **dict.fromkeys(
-                ["ajrhf1aj", "z5ztlw3k"],  # PARKSIDE Smart battery
+                ["ajrhf1aj", "z5ztlw3k", "vllfabvs", "fay1puxy"],  # PARKSIDE Smart battery
                 [
                     TuyaBLETextMapping(
                         dp_id=106,


### PR DESCRIPTION
### **Summary**

Fix #33 

This PR adds support for two additional Parkside battery models and fixes several accuracy issues in the existing battery integration logic.

### **New device support**

Added support for Parkside 4Ah battery (product_id: _`vllfabvs`_) — a different battery type than the one currently supported.
Added support for Parkside 12Ah battery (product_id: _`fay1puxy`_).

### **Bug fixes**

Fixed battery status mapping (Sleep, Charging, etc.) — the previous status map contained incorrect value mappings, causing the integration to report the wrong state for the battery.
Fixed current and voltage readings — several sensor values were being read with incorrect scaling. Added the appropriate multipliers so that current and voltage values are now reported correctly.

### **Important note on Bluetooth proxy usage**

I would not recommend keeping a battery paired with Home Assistant in close proximity to a Bluetooth proxy that is set to active mode. In this configuration, the battery's BLE module never gets a chance to enter sleep mode, since the proxy keeps actively polling/maintaining the connection. Over time, this can cause the battery to discharge unnecessarily, even when it's not in use.
If you're using an active Bluetooth proxy, consider either switching it to passive mode for this device, or placing the proxy far enough from the battery that it doesn't maintain a persistent active connection.