### PR TITLE
feat: enhance diagnostics support (via @SittingDuck52)

### DIFF
--- a/custom_components/tuya_ble/diagnostics.py
+++ b/custom_components/tuya_ble/diagnostics.py
@@ -101,9 +101,9 @@ async def async_get_config_entry_diagnostics(
         "protocol_version": device.protocol_version,
         "keep_connection": getattr(device, "keep_connection", False),
         "connected": is_connected,
-        "coordinator_connected": data.coordinator.connected
-        if data.coordinator
-        else False,
+        "coordinator_connected": (
+            data.coordinator.connected if data.coordinator else False
+        ),
         "seconds_since_last_connect": seconds_since_last_connect,
         "last_connect_error": getattr(device, "last_connect_error", None),
         "rssi": device.rssi,

--- a/custom_components/tuya_ble/diagnostics.py
+++ b/custom_components/tuya_ble/diagnostics.py
@@ -1,36 +1,134 @@
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
+"""Diagnostics support for Tuya BLE."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from homeassistant.components import bluetooth
 from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_ACCESS_ID,
+    CONF_ACCESS_SECRET,
+    CONF_LOCAL_KEY,
+    CONF_SEC_KEY,
+    CONF_UUID,
+    DOMAIN,
+)
+from .devices import TuyaBLEData
 
 TO_REDACT = {
-    "username",
-    "password",
-    "access_secret",
-    "local_key",
-    "sec_key",
+    CONF_ACCESS_ID,
+    CONF_ACCESS_SECRET,
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    CONF_LOCAL_KEY,
+    CONF_SEC_KEY,
+    CONF_UUID,
     "api_key",
     "token",
-    "host",
     "mac",
 }
 
 
-async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry):
-    data = {
-        "entry": entry.as_dict(),
-        "data": entry.data,
-        "options": entry.options,
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    address: str = entry.data.get(CONF_ADDRESS, "")
+    result: dict[str, Any] = {
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": async_redact_data(dict(entry.options), TO_REDACT),
+        },
     }
-    return async_redact_data(data, TO_REDACT)
+
+    # Bluetooth visibility, independent of whether the entry is loaded
+    service_info = (
+        bluetooth.async_last_service_info(hass, address, connectable=True)
+        if address
+        else None
+    )
+    result["bluetooth"] = {
+        "seen": service_info is not None,
+        "rssi": service_info.rssi if service_info else None,
+        "source": service_info.source if service_info else None,
+        "name": service_info.name if service_info else None,
+        "connectable": service_info.connectable if service_info else None,
+        "connectable_scanner_count": bluetooth.async_scanner_count(
+            hass, connectable=True
+        ),
+    }
+
+    data: TuyaBLEData | None = getattr(entry, "runtime_data", None)
+    if data is None and DOMAIN in hass.data:
+        data = hass.data[DOMAIN].get(entry.entry_id)
+
+    if data is None:
+        result["device"] = {"loaded": False}
+        return result
+
+    device = data.device
+    is_connected = getattr(
+        device,
+        "is_connected",
+        bool(
+            getattr(device, "_client", None)
+            and getattr(device._client, "is_connected", False)
+            and getattr(device, "_is_paired", False)
+        ),
+    )
+    seconds_since_last_connect = None
+    last_connected_at = getattr(device, "last_connected_at", None)
+    if last_connected_at is not None:
+        seconds_since_last_connect = round(time.monotonic() - last_connected_at, 1)
+
+    result["device"] = {
+        "loaded": True,
+        "address": device.address,
+        "name": device.name,
+        "product_id": device.product_id,
+        "category": device.category,
+        "product_name": device.product_name,
+        "product_model": device.product_model,
+        "device_version": device.device_version,
+        "hardware_version": device.hardware_version,
+        "protocol_version": device.protocol_version,
+        "keep_connection": getattr(device, "keep_connection", False),
+        "connected": is_connected,
+        "coordinator_connected": data.coordinator.connected
+        if data.coordinator
+        else False,
+        "seconds_since_last_connect": seconds_since_last_connect,
+        "last_connect_error": getattr(device, "last_connect_error", None),
+        "rssi": device.rssi,
+    }
+    result["product_info"] = (
+        {"manufacturer": data.product.manufacturer, "name": data.product.name}
+        if data.product
+        else None
+    )
+    result["datapoints"] = [
+        {
+            "id": dp.id,
+            "type": dp.type.name if dp.type else None,
+            "value": (
+                dp.value
+                if not isinstance(dp.value, (bytes, bytearray))
+                else dp.value.hex()
+            ),
+        }
+        for dp in _iter_datapoints(device)
+    ]
+    return result
 
 
-async def async_get_device_diagnostics(hass: HomeAssistant, entry, device):
-    # Optional: if your integration uses devices (via the device registry)
-    device_data = {
-        "device_name": device.name,
-        "identifiers": list(device.identifiers),
-        "manufacturer": device.manufacturer,
-        "model": device.model,
-        # Add any other relevant device details here
-    }
-    return async_redact_data(device_data, TO_REDACT)
+def _iter_datapoints(device) -> list:
+    dps = device.datapoints
+    inner = getattr(dps, "_datapoints", {})
+    return [inner[k] for k in sorted(inner)]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,150 @@
+"""Test Tuya BLE diagnostics."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.tuya_ble.const import (
+    CONF_ACCESS_ID,
+    CONF_ACCESS_SECRET,
+    CONF_LOCAL_KEY,
+    CONF_SEC_KEY,
+    CONF_UUID,
+    DOMAIN,
+)
+from custom_components.tuya_ble.devices import (
+    TuyaBLECoordinator,
+    TuyaBLEData,
+    TuyaBLEDevice,
+    TuyaBLEProductInfo,
+)
+from custom_components.tuya_ble.diagnostics import async_get_config_entry_diagnostics
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDataPointType
+
+from . import DEVICE_ADDRESS
+
+
+async def test_diagnostics_unloaded_entry(hass: HomeAssistant) -> None:
+    """Test diagnostics output when the config entry is not loaded."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": DEVICE_ADDRESS,
+            CONF_ACCESS_ID: "secret_access_id",
+            CONF_LOCAL_KEY: "secret_local_key",
+        },
+        title="Unloaded Entry",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.bluetooth.async_last_service_info", return_value=None), patch(
+        "homeassistant.components.bluetooth.async_scanner_count", return_value=2
+    ):
+        diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["entry"]["title"] == "Unloaded Entry"
+    assert diagnostics["entry"]["data"][CONF_ACCESS_ID] == "**REDACTED**"
+    assert diagnostics["entry"]["data"][CONF_LOCAL_KEY] == "**REDACTED**"
+    assert diagnostics["bluetooth"] == {
+        "seen": False,
+        "rssi": None,
+        "source": None,
+        "name": None,
+        "connectable": None,
+        "connectable_scanner_count": 2,
+    }
+    assert diagnostics["device"] == {"loaded": False}
+
+
+async def test_diagnostics_loaded_entry(hass: HomeAssistant) -> None:
+    """Test diagnostics output when the config entry is loaded with device data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "address": DEVICE_ADDRESS,
+            CONF_ACCESS_ID: "secret_access_id",
+            CONF_ACCESS_SECRET: "secret_access_secret",
+            CONF_LOCAL_KEY: "secret_local_key",
+            CONF_SEC_KEY: "secret_sec_key",
+            CONF_UUID: "secret_uuid",
+        },
+        options={},
+        title="Loaded Entry",
+    )
+    entry.add_to_hass(hass)
+
+    ble_device = Mock(name="mock_ble_device", address=DEVICE_ADDRESS, rssi=-65)
+    manager = Mock()
+    manager.get_device_credentials = AsyncMock(return_value=None)
+
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+
+    # Add datapoints to test formatting
+    device.datapoints._update_from_device(1, 0, 0, TuyaBLEDataPointType.DT_BOOL, True)
+    device.datapoints._update_from_device(2, 0, 0, TuyaBLEDataPointType.DT_VALUE, 42)
+    device.datapoints._update_from_device(
+        3, 0, 0, TuyaBLEDataPointType.DT_RAW, bytes.fromhex("01020304")
+    )
+
+    product_info = TuyaBLEProductInfo(name="Test Product", manufacturer="Test Maker")
+    coordinator = TuyaBLECoordinator(hass, device)
+
+    data = TuyaBLEData(
+        title="Loaded Entry",
+        device=device,
+        product=product_info,
+        manager=manager,
+        coordinator=coordinator,
+    )
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = data
+
+    service_info = Mock(
+        spec=BluetoothServiceInfoBleak,
+        rssi=-65,
+        source="local_adapter",
+        connectable=True,
+    )
+    service_info.name = "TuyaBLEDevice"
+
+    with patch(
+        "homeassistant.components.bluetooth.async_last_service_info", return_value=service_info
+    ), patch("homeassistant.components.bluetooth.async_scanner_count", return_value=3):
+        diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    # Verify entry redaction
+    assert diagnostics["entry"]["data"][CONF_ACCESS_ID] == "**REDACTED**"
+    assert diagnostics["entry"]["data"][CONF_ACCESS_SECRET] == "**REDACTED**"
+    assert diagnostics["entry"]["data"][CONF_LOCAL_KEY] == "**REDACTED**"
+    assert diagnostics["entry"]["data"][CONF_SEC_KEY] == "**REDACTED**"
+    assert diagnostics["entry"]["data"][CONF_UUID] == "**REDACTED**"
+
+    # Verify bluetooth details
+    assert diagnostics["bluetooth"] == {
+        "seen": True,
+        "rssi": -65,
+        "source": "local_adapter",
+        "name": "TuyaBLEDevice",
+        "connectable": True,
+        "connectable_scanner_count": 3,
+    }
+
+    # Verify device state details
+    assert diagnostics["device"]["loaded"] is True
+    assert diagnostics["device"]["address"] == DEVICE_ADDRESS
+    assert diagnostics["device"]["coordinator_connected"] is False
+
+    # Verify product info
+    assert diagnostics["product_info"] == {
+        "manufacturer": "Test Maker",
+        "name": "Test Product",
+    }
+
+    # Verify formatted datapoints
+    assert diagnostics["datapoints"] == [
+        {"id": 1, "type": "DT_BOOL", "value": True},
+        {"id": 2, "type": "DT_VALUE", "value": 42},
+        {"id": 3, "type": "DT_RAW", "value": "01020304"},
+    ]


### PR DESCRIPTION
A version of the diagnostics in #289

Enhanced custom_components/tuya_ble/diagnostics.py to report comprehensive diagnostic information including redacted config entry data/options, Bluetooth visibility and scanner counts, detailed device state and timing, product information, and sorted/formatted datapoints. Added unit tests in tests/test_diagnostics.py.

---
*PR created automatically by Jules for task [12749016227803803338](https://jules.google.com/task/12749016227803803338) started by @CloCkWeRX*