### PR TITLE
fix: Retry the initial update instead of losing it in an unwatched task

### DIFF
--- a/custom_components/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from bleak_retry_connector import BLEAK_RETRY_EXCEPTIONS as BLEAK_EXCEPTIONS, get_device
@@ -57,16 +58,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     product_info = get_device_product_info(device)
 
     coordinator = TuyaBLECoordinator(hass, device)
-    """
-    try:
-        await device.update()
-    except BLEAK_EXCEPTIONS as ex:
-        raise ConfigEntryNotReady(
-            f"Could not communicate with Tuya BLE device with address {address}"
-        ) from ex
-    """
 
-    hass.add_job(device.update())
+    async def _initial_update() -> None:
+        """Perform the first update, retrying until the device answers.
+
+        The first update used to be fired with `hass.add_job()` and never awaited.
+        When the device is out of range while the entry is being set up,
+        `_ensure_connected()` exhausts its attempts and raises `BleakNotFoundError`
+        out of a task nobody watches ("Task exception was never retrieved"), so the
+        device is never polled again and stays unavailable until Home Assistant is
+        restarted. Retrying in an entry-scoped background task keeps the device
+        recoverable without a restart; the task is cancelled when the entry unloads.
+        """
+        delay = 60
+        while True:
+            try:
+                # Cap a single attempt: `_ensure_connected()` retries internally and
+                # can occupy the task for a long time, which would delay the next
+                # real attempt long after the device became reachable again.
+                await asyncio.wait_for(device.update(), 240)
+                return
+            except BLEAK_EXCEPTIONS + (TimeoutError,) as ex:
+                _LOGGER.debug(
+                    "%s: Initial update failed (%s); retrying in %s s",
+                    address,
+                    type(ex).__name__,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, 300)
+
+    entry.async_create_background_task(
+        hass, _initial_update(), f"tuya_ble initial update {address}"
+    )
 
     @callback
     def _async_update_ble(


### PR DESCRIPTION
### Problem

The first update after setup is scheduled with `hass.add_job(device.update())` and never awaited. If the device is out of range at that moment, `_ensure_connected()` exhausts its attempts and raises `BleakNotFoundError` out of a task nobody watches:

```
ERROR homeassistant: Error doing job: Task exception was never retrieved (task: None)
Traceback (most recent call last):
  File "/config/custom_components/tuya_ble/tuya_ble/tuya_ble.py", line 359, in update
    await self._send_packet(TuyaBLECode.FUN_SENDER_DEVICE_STATUS, bytes())
  File "/config/custom_components/tuya_ble/tuya_ble/tuya_ble.py", line 1006, in _send_packet
    await self._ensure_connected()
  File "/config/custom_components/tuya_ble/tuya_ble/tuya_ble.py", line 722, in _ensure_connected
    raise BleakNotFoundError()
bleak_retry_connector.BleakNotFoundError
```

After that, nothing retries. The entry stays `loaded`, the device stays `unavailable`, and only a Home Assistant restart brings it back. The proper handling (`try/except BLEAK_EXCEPTIONS` -> `ConfigEntryNotReady`) is present but commented out right above that line.

With four soil sensors (SGS01) sharing one ESPHome Bluetooth proxy, this hit us repeatedly: whichever sensor happened to be silent during setup was dead until the next restart. Every occurrence looked different (a different plant each time), which is why it took a while to recognise as one bug.

### Change

Run the initial update in an entry-scoped background task that catches the Bleak exceptions and retries with a backoff (60 s, doubling, capped at 300 s). A single attempt is bounded with `asyncio.wait_for(..., 240)`, because `_ensure_connected()` retries internally and can otherwise occupy the task long after the device became reachable again. `entry.async_create_background_task()` cancels the task when the entry unloads.

### Testing

Running on 4 × SGS01 (`zwjcy` / `gvygg3m8`) via an ESPHome proxy since 2026-08-14, on top of 0.8.1.

- Before: a sensor that missed its setup window logged one `Connecting, all attempts failed` and then nothing at all - silence in the log for 19 hours, while the other three sensors kept reconnecting normally.
- After: the same situation produces repeated attempts (15 series logged over one day), and a sensor that dropped during a restart came back **on its own after ~1.5 h** without any intervention - previously that required a restart.

I am happy to split the `wait_for` cap into a separate commit if you would rather keep the change minimal.

AI-assisted, tested on a live installation.
