### PR TITLE
fix: Do not let unload block forever on the connection lock

### DIFF
--- a/custom_components/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from bleak_retry_connector import BLEAK_RETRY_EXCEPTIONS as BLEAK_EXCEPTIONS, get_device
@@ -119,6 +120,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         data: TuyaBLEData = hass.data[DOMAIN].pop(entry.entry_id)
-        await data.device.stop()
+        # stop() -> _execute_disconnect() waits for self._connect_lock, which
+        # _ensure_connected() holds for the whole duration of its retry loop.
+        # While that loop runs, unloading blocks and the entry is stuck in
+        # ConfigEntryState.UNLOAD_IN_PROGRESS, so reloading the entry (and every
+        # operation that reloads it, e.g. renaming it or changing its options)
+        # never completes and only a Home Assistant restart clears it.
+        # Give the disconnect a bounded amount of time; the abandoned connection
+        # is dropped by the adapter/proxy anyway once the client is discarded.
+        try:
+            await asyncio.wait_for(data.device.stop(), 15)
+        except TimeoutError:
+            _LOGGER.warning(
+                "%s: Timed out waiting for the device to disconnect, unloading anyway",
+                entry.data[CONF_ADDRESS],
+            )
 
     return unload_ok


### PR DESCRIPTION
### Problem

`async_unload_entry()` awaits `device.stop()`, which goes through `_execute_disconnect()`:

```python
async def _execute_disconnect(self) -> None:
    async with self._connect_lock:      # <- waits here
        ...
```

`_ensure_connected()` holds that same `self._connect_lock` for its **entire** retry loop (`attempts_count = 100`), which for an unreachable device can run for a long time. So unloading an entry while a connection attempt is in progress simply blocks: the entry stays in `ConfigEntryState.UNLOAD_IN_PROGRESS`, and reloading it - or anything that reloads it, such as renaming the entry or saving its options - never completes. The only way out is restarting Home Assistant.

This is what makes the well-known "reload wedges the entry" behaviour reproducible: it is not a mysterious hang, it is two coroutines contending for one lock.

### Change

Bound the disconnect with `asyncio.wait_for(data.device.stop(), 15)` and log a warning when it times out. The abandoned connection is dropped by the adapter or proxy once the client is discarded.

### Testing

Running since 2026-08-15 on top of 0.8.1, four SGS01 sensors.

- Before: reloading an entry whose device was mid-connection left it in `UNLOAD_IN_PROGRESS` for hours; recovering meant restarting Core.
- After, both paths verified: when nothing is stuck the reload returns in **0.1 s**; when `stop()` really is blocked the reload returns after **15.1 s** (the timeout), logs the warning, and the entry ends up `loaded` - never `UNLOAD_IN_PROGRESS`.

This also makes recovery from a rotated `local_key` practical: refresh the credentials via the options flow, reload the entry, done - no restart.

AI-assisted, tested on a live installation.
