### PR TITLE
test: cover unloading while a connection attempt is in progress

### DIFF
--- a/custom_components/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/__init__.py
@@ -39,6 +39,9 @@ PLATFORMS: list[Platform] = [
 
 _LOGGER = logging.getLogger(__name__)
 
+# How long unloading waits for a disconnect before giving up on it.
+DISCONNECT_TIMEOUT = 15
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Tuya BLE from a config entry."""
@@ -152,7 +155,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Give the disconnect a bounded amount of time; the abandoned connection
         # is dropped by the adapter/proxy anyway once the client is discarded.
         try:
-            await asyncio.wait_for(data.device.stop(), 15)
+            await asyncio.wait_for(data.device.stop(), DISCONNECT_TIMEOUT)
         except TimeoutError:
             _LOGGER.warning(
                 "%s: Timed out waiting for the device to disconnect, unloading anyway",

--- a/tests/test_unload_disconnect_timeout.py
+++ b/tests/test_unload_disconnect_timeout.py
@@ -1,0 +1,119 @@
+"""Tests for unloading an entry while a connection attempt is in progress."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from bleak.backends.device import BLEDevice
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.tuya_ble import async_unload_entry
+from custom_components.tuya_ble.cloud import HASSTuyaBLEDeviceManager
+from custom_components.tuya_ble.const import DOMAIN
+from custom_components.tuya_ble.tuya_ble import TuyaBLEDevice
+
+ADDRESS = "11:22:33:44:55:66"
+
+CONFIG = {
+    "1234": {
+        "address": ADDRESS,
+        "device_id": "767823809c9c1f458745",
+        "protocol_version": "3.3",
+        "local_key": "wV[NcWGUSFF`dSgO",
+        "friendly_name": "Local 3G",
+    }
+}
+
+
+def _entry_with_device(hass: HomeAssistant, device) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"devices": CONFIG, "address": ADDRESS},
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+    data = Mock()
+    data.device = device
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = data
+    return entry
+
+
+async def _make_device(hass: HomeAssistant) -> TuyaBLEDevice:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"devices": CONFIG, "address": ADDRESS},
+        title="Mock TuyaBLE",
+    )
+    entry.add_to_hass(hass)
+    ble_device = BLEDevice(name="bob", address=ADDRESS, details="", rssi=-50)
+    manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
+    device = TuyaBLEDevice(manager, ble_device)
+    await device.initialize()
+    return device
+
+
+async def test_disconnect_waits_for_the_connection_lock(hass: HomeAssistant) -> None:
+    """This is what makes unloading hang.
+
+    _execute_disconnect() takes self._connect_lock, and _ensure_connected() holds
+    that lock for its whole retry loop, so a disconnect requested during a
+    connection attempt does not complete until that loop is done.
+    """
+    device = await _make_device(hass)
+
+    async with device._connect_lock:
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(device.stop(), 0.05)
+
+
+async def test_unload_gives_up_on_a_stuck_disconnect(hass: HomeAssistant) -> None:
+    """A disconnect that never returns must not keep the entry loaded forever."""
+    device = Mock()
+    never_returns = asyncio.Event()
+    device.stop = AsyncMock(side_effect=never_returns.wait)
+    entry = _entry_with_device(hass, device)
+
+    with (
+        patch.object(
+            hass.config_entries, "async_unload_platforms", AsyncMock(return_value=True)
+        ),
+        patch("custom_components.tuya_ble.DISCONNECT_TIMEOUT", 0.05),
+    ):
+        assert await async_unload_entry(hass, entry) is True
+
+    device.stop.assert_awaited_once()
+    assert entry.entry_id not in hass.data[DOMAIN]
+    never_returns.set()
+
+
+async def test_unload_awaits_a_clean_disconnect(hass: HomeAssistant) -> None:
+    """The normal path is unchanged: the disconnect is awaited, then we unload."""
+    device = Mock()
+    device.stop = AsyncMock()
+    entry = _entry_with_device(hass, device)
+
+    with patch.object(
+        hass.config_entries, "async_unload_platforms", AsyncMock(return_value=True)
+    ):
+        assert await async_unload_entry(hass, entry) is True
+
+    device.stop.assert_awaited_once()
+    assert entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_failed_platform_unload_leaves_the_device_alone(
+    hass: HomeAssistant,
+) -> None:
+    """If the platforms refuse to unload, nothing is torn down."""
+    device = Mock()
+    device.stop = AsyncMock()
+    entry = _entry_with_device(hass, device)
+
+    with patch.object(
+        hass.config_entries, "async_unload_platforms", AsyncMock(return_value=False)
+    ):
+        assert await async_unload_entry(hass, entry) is False
+
+    device.stop.assert_not_awaited()
+    assert entry.entry_id in hass.data[DOMAIN]


### PR DESCRIPTION
Follow-up to #298, and an answer to your question there: 0.8.2 has the problem. #277 fixes a different thing - the notification watcher that stayed registered after an unexpected disconnect. The lock contention is untouched: `_execute_disconnect()` takes `self._connect_lock`, `_ensure_connected()` holds it for the whole 100-attempt loop, and `async_unload_entry()` awaits `stop()` unconditionally. That is the same in 0.8.1, 0.8.2, 0.8.3 and 0.9.0.

This adds the tests for it:

- `test_disconnect_waits_for_the_connection_lock` holds `_connect_lock` and shows `stop()` cannot finish while it is held. This is the actual bug; without it the timeout in #298 looks like an arbitrary number.
- `test_unload_gives_up_on_a_stuck_disconnect` - a disconnect that never returns, entry still unloads.
- `test_unload_awaits_a_clean_disconnect` - normal path unchanged.
- `test_failed_platform_unload_leaves_the_device_alone` - nothing is torn down when the platforms refuse.

The timeout moves into `DISCONNECT_TIMEOUT` so the test can shorten it to 50 ms instead of waiting 15 s.

Checked that the test actually catches the regression: with the `wait_for` from #298 reverted, `test_unload_gives_up_on_a_stuck_disconnect` hangs and fails on timeout; with it in place the file passes in 0.2 s. Full suite: 63 passed. Black and codespell clean.

AI-assisted.
