### PR TITLE
fix(device): Add support for CTL20H_8018 SmartLock (qcrilcpr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ See a device marked Experimental you have? We could use real world testing feedb
       <td>—</td>
     </tr>
     <tr>
-      <td>Drawer Lock CTL20H</td>
-      <td><code>y2yaegze</code></td>
+      <td>Drawer Lock CTL20H / CTL20H_8018 SmartLock</td>
+      <td><code>y2yaegze</code>, <code>qcrilcpr</code></td>
       <td>—</td>
     </tr>
     <tr>

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -463,7 +463,13 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
     ),
     "jtmspro": TuyaBLECategoryInfo(
         products={
-            "y2yaegze": TuyaBLEProductInfo(name="Drawer Lock CTL20H", lock=1),
+            **dict.fromkeys(
+                [
+                    "y2yaegze",
+                    "qcrilcpr",
+                ],
+                TuyaBLEProductInfo(name="Drawer Lock CTL20H", lock=1),
+            ),
             "hc7n0urm": TuyaBLEProductInfo(  # device product_id
                 name="A1 Ultra-JM",
             ),

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -545,33 +545,39 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
     ),
     "jtmspro": TuyaBLECategorySensorMapping(
         products={
-            "y2yaegze": [
-                TuyaBLEAlarmLockStateMapping(dp_id=21),
-                TuyaBLESensorMapping(
-                    dp_id=15,  # Retrieve last card used
-                    description=SensorEntityDescription(
-                        key="unlock_card",
-                        icon="mdi:nfc-variant",
+            **dict.fromkeys(
+                [
+                    "y2yaegze",
+                    "qcrilcpr",
+                ],
+                [
+                    TuyaBLEAlarmLockStateMapping(dp_id=21),
+                    TuyaBLESensorMapping(
+                        dp_id=15,  # Retrieve last card used
+                        description=SensorEntityDescription(
+                            key="unlock_card",
+                            icon="mdi:nfc-variant",
+                        ),
                     ),
-                ),
-                TuyaBLESensorMapping(
-                    dp_id=19,  # Retrieve last BLE used
-                    description=SensorEntityDescription(
-                        key="unlock_ble",
-                        icon="mdi:bluetooth",
+                    TuyaBLESensorMapping(
+                        dp_id=19,  # Retrieve last BLE used
+                        description=SensorEntityDescription(
+                            key="unlock_ble",
+                            icon="mdi:bluetooth",
+                        ),
                     ),
-                ),
-                TuyaBLESensorMapping(
-                    dp_id=62,  # Retrieve last remote phone used
-                    description=SensorEntityDescription(
-                        key="unlock_phone_remote",
-                        icon="mdi:cellphone-lock",
-                        suggested_display_precision=0,
-                        entity_category=EntityCategory.DIAGNOSTIC,
+                    TuyaBLESensorMapping(
+                        dp_id=62,  # Retrieve last remote phone used
+                        description=SensorEntityDescription(
+                            key="unlock_phone_remote",
+                            icon="mdi:cellphone-lock",
+                            suggested_display_precision=0,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                        ),
                     ),
-                ),
-                TuyaBLEBatteryMapping(dp_id=8),
-            ],
+                    TuyaBLEBatteryMapping(dp_id=8),
+                ],
+            ),
             "hc7n0urm": [  # A1 Ultra-JM
                 TuyaBLESensorMapping(
                     dp_id=21,  # Alarm event

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -599,16 +599,22 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
     ),
     "jtmspro": TuyaBLECategorySwitchMapping(
         products={
-            "y2yaegze": [
-                TuyaBLESwitchMapping(
-                    dp_id=33,
-                    description=SwitchEntityDescription(
-                        key="automatic_lock",
-                        icon="mdi:lock-clock",
-                        entity_category=EntityCategory.CONFIG,
+            **dict.fromkeys(
+                [
+                    "y2yaegze",
+                    "qcrilcpr",
+                ],
+                [
+                    TuyaBLESwitchMapping(
+                        dp_id=33,
+                        description=SwitchEntityDescription(
+                            key="automatic_lock",
+                            icon="mdi:lock-clock",
+                            entity_category=EntityCategory.CONFIG,
+                        ),
                     ),
-                ),
-            ],
+                ],
+            ),
             **dict.fromkeys(
                 [
                     "stugc8dl",


### PR DESCRIPTION
Add product mapping for product ID qcrilcpr (CTL20H_8018 SmartLock) under jtmspro category, enabling lock, sensor (alarm lock, unlock card, unlock BLE, unlock phone remote, battery), and switch (automatic lock) entities.

---
*PR created automatically by Jules for task [12665144943325101292](https://jules.google.com/task/12665144943325101292) started by @CloCkWeRX*