### PR TITLE
fix(diagnostics): default keep_connection fallback to True

### DIFF
--- a/custom_components/tuya_ble/diagnostics.py
+++ b/custom_components/tuya_ble/diagnostics.py
@@ -99,7 +99,7 @@ async def async_get_config_entry_diagnostics(
         "device_version": device.device_version,
         "hardware_version": device.hardware_version,
         "protocol_version": device.protocol_version,
-        "keep_connection": getattr(device, "keep_connection", False),
+        "keep_connection": getattr(device, "keep_connection", True),
         "connected": is_connected,
         "coordinator_connected": (
             data.coordinator.connected if data.coordinator else False

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -134,6 +134,7 @@ async def test_diagnostics_loaded_entry(hass: HomeAssistant) -> None:
     # Verify device state details
     assert diagnostics["device"]["loaded"] is True
     assert diagnostics["device"]["address"] == DEVICE_ADDRESS
+    assert diagnostics["device"]["keep_connection"] is True
     assert diagnostics["device"]["coordinator_connected"] is False
 
     # Verify product info


### PR DESCRIPTION
Fixes a misleading `keep_connection: false` report in diagnostics dumps by setting the `getattr` fallback for `keep_connection` to `True` to accurately reflect the integration's current behavior of holding connections permanently.

---
*PR created automatically by Jules for task [317206755290548027](https://jules.google.com/task/317206755290548027) started by @CloCkWeRX*