### PR TITLE
fix: skip cloud login and cache build for manual entries

### DIFF
--- a/custom_components/tuya_ble/cloud.py
+++ b/custom_components/tuya_ble/cloud.py
@@ -126,7 +126,7 @@ class HASSTuyaBLEDeviceManager(AbstaractTuyaBLEDeviceManager):
         """Login into Tuya cloud using credentials from data dictionary."""
         global _cache
 
-        if len(data) == 0:
+        if len(data) == 0 or not self._has_login(data):
             return {}
 
         api = TuyaOpenAPI(
@@ -248,6 +248,8 @@ class HASSTuyaBLEDeviceManager(AbstaractTuyaBLEDeviceManager):
         for config_entry in tuya_config_entries:
             data.clear()
             data.update(config_entry.data)
+            if not self._has_login(data):
+                continue
             key = self._get_cache_key(data)
             item = _cache.get(key)
             if item is None or len(item.credentials) == 0:
@@ -260,6 +262,8 @@ class HASSTuyaBLEDeviceManager(AbstaractTuyaBLEDeviceManager):
         for config_entry in ble_config_entries:
             data.clear()
             data.update(config_entry.options)
+            if not self._has_login(data):
+                continue
             key = self._get_cache_key(data)
             item = _cache.get(key)
             if item is None or len(item.credentials) == 0:

--- a/custom_components/tuya_ble/config_flow.py
+++ b/custom_components/tuya_ble/config_flow.py
@@ -347,7 +347,10 @@ class TuyaBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovery_info = discovery_info
         if self._manager is None:
             self._manager = HASSTuyaBLEDeviceManager(self.hass, self._data)
-        await self._manager.build_cache()
+        try:
+            await self._manager.build_cache()
+        except Exception:
+            _LOGGER.exception("Error building cloud cache during bluetooth step")
         self.context["title_placeholders"] = {
             "name": await get_device_readable_name(
                 discovery_info,
@@ -362,7 +365,10 @@ class TuyaBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         """Choose between cloud lookup and manual credentials."""
         if self._manager is None:
             self._manager = HASSTuyaBLEDeviceManager(self.hass, self._data)
-            await self._manager.build_cache()
+            try:
+                await self._manager.build_cache()
+            except Exception:
+                _LOGGER.exception("Error building cloud cache during user step")
         return self.async_show_menu(
             step_id="user",
             menu_options=["login", "manual"],

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -208,3 +208,52 @@ def test_credentials_and_diagnostics_redact_both_keys() -> None:
     assert CONF_LOCAL_KEY in TO_REDACT
     assert CONF_SEC_KEY in TO_REDACT
     assert CONF_ACCESS_SECRET in TO_REDACT
+
+
+async def test_login_and_build_cache_skip_manual_entries(
+    hass: HomeAssistant,
+) -> None:
+    """Manual entries lacking Tuya Cloud login keys return {} on login and are skipped in build_cache."""
+    manual_data = {
+        CONF_UUID: "1234567890abcdef",
+        CONF_LOCAL_KEY: LOCAL_KEY,
+        CONF_DEVICE_ID: "12345678901234567890",
+        CONF_CATEGORY: "test",
+        CONF_PRODUCT_ID: "test-product",
+        CONF_DEVICE_NAME: "Manual Device",
+    }
+    manager = HASSTuyaBLEDeviceManager(hass, manual_data)
+
+    # Calling _login on manual entry data returns empty dict without throwing missing scheme error
+    result = await manager._login(manual_data, True)
+    assert result == {}
+
+    # Mock config entries with a manual BLE config entry lacking login keys
+    entry = Mock()
+    entry.options = manual_data
+    original_async_entries = hass.config_entries.async_entries
+    hass.config_entries.async_entries = Mock(side_effect=lambda domain=None: [entry] if domain == "tuya_ble" else [])
+
+    try:
+        # build_cache runs without raising missing scheme error
+        await manager.build_cache()
+    finally:
+        hass.config_entries.async_entries = original_async_entries
+
+
+async def test_config_flow_handles_build_cache_exceptions(
+    hass: HomeAssistant,
+) -> None:
+    """ConfigFlow async_step_user continues even if build_cache raises an exception."""
+    from custom_components.tuya_ble.config_flow import TuyaBLEConfigFlow
+
+    flow = TuyaBLEConfigFlow()
+    flow.hass = hass
+
+    with AsyncMock() as mock_manager:
+        mock_manager.build_cache.side_effect = Exception("Cloud API unreachable")
+        flow._manager = mock_manager
+
+        result = await flow.async_step_user()
+        assert result["type"] == "menu"
+        assert result["step_id"] == "user"


### PR DESCRIPTION
Fixes regression where manual config entries without Tuya Cloud login credentials cause a 500 error when re-opening the "Add entry" config flow.

---
*PR created automatically by Jules for task [9033758951520221000](https://jules.google.com/task/9033758951520221000) started by @CloCkWeRX*