### PR TITLE
feat: optional on-demand BLE connection mode

### DIFF
--- a/custom_components/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/__init__.py
@@ -17,7 +17,13 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .tuya_ble import TuyaBLEDevice
 
 from .cloud import HASSTuyaBLEDeviceManager
-from .const import DOMAIN
+from .const import (
+    CONF_IDLE_DISCONNECT_DELAY,
+    CONF_KEEP_CONNECTION,
+    DEFAULT_IDLE_DISCONNECT_DELAY,
+    DEFAULT_KEEP_CONNECTION,
+    DOMAIN,
+)
 from .devices import TuyaBLECoordinator, TuyaBLEData, get_device_product_info
 
 PLATFORMS: list[Platform] = [
@@ -56,7 +62,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     manager = HASSTuyaBLEDeviceManager(hass, entry.options.copy())
-    device = TuyaBLEDevice(manager, ble_device)
+    device = TuyaBLEDevice(
+        manager,
+        ble_device,
+        keep_connection=entry.options.get(
+            CONF_KEEP_CONNECTION, DEFAULT_KEEP_CONNECTION
+        ),
+        idle_disconnect_delay=entry.options.get(
+            CONF_IDLE_DISCONNECT_DELAY, DEFAULT_IDLE_DISCONNECT_DELAY
+        ),
+    )
     await device.initialize()
     product_info = get_device_product_info(device)
 
@@ -138,6 +153,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
     data: TuyaBLEData = hass.data[DOMAIN][entry.entry_id]
+    if (
+        entry.options.get(CONF_KEEP_CONNECTION, DEFAULT_KEEP_CONNECTION)
+        != data.device.keep_connection
+    ):
+        await hass.config_entries.async_reload(entry.entry_id)
+        return
     if entry.title != data.title:
         await hass.config_entries.async_reload(entry.entry_id)
 

--- a/custom_components/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/__init__.py
@@ -156,6 +156,8 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     if (
         entry.options.get(CONF_KEEP_CONNECTION, DEFAULT_KEEP_CONNECTION)
         != data.device.keep_connection
+        or entry.options.get(CONF_IDLE_DISCONNECT_DELAY, DEFAULT_IDLE_DISCONNECT_DELAY)
+        != data.device.idle_disconnect_delay
     ):
         await hass.config_entries.async_reload(entry.entry_id)
         return

--- a/custom_components/tuya_ble/config_flow.py
+++ b/custom_components/tuya_ble/config_flow.py
@@ -53,8 +53,12 @@ from .const import (
     CONF_PRODUCT_ID,
     CONF_PRODUCT_MODEL,
     CONF_PRODUCT_NAME,
+    CONF_IDLE_DISCONNECT_DELAY,
+    CONF_KEEP_CONNECTION,
     CONF_SEC_KEY,
     CONF_UUID,
+    DEFAULT_IDLE_DISCONNECT_DELAY,
+    DEFAULT_KEEP_CONNECTION,
     DOMAIN,
 )
 from .devices import TuyaBLEData, get_device_readable_name
@@ -244,6 +248,24 @@ def _validate_manual(
     return result
 
 
+def _settings_schema(defaults: dict[str, Any]) -> vol.Schema:
+    """Schema for the connection policy."""
+    return vol.Schema(
+        {
+            vol.Required(
+                CONF_KEEP_CONNECTION,
+                default=defaults.get(CONF_KEEP_CONNECTION, DEFAULT_KEEP_CONNECTION),
+            ): bool,
+            vol.Required(
+                CONF_IDLE_DISCONNECT_DELAY,
+                default=defaults.get(
+                    CONF_IDLE_DISCONNECT_DELAY, DEFAULT_IDLE_DISCONNECT_DELAY
+                ),
+            ): vol.All(vol.Coerce(int), vol.Range(min=5, max=3600)),
+        }
+    )
+
+
 class TuyaBLEOptionsFlow(OptionsFlowWithConfigEntry):
     """Handle a Tuya BLE options flow."""
 
@@ -257,7 +279,21 @@ class TuyaBLEOptionsFlow(OptionsFlowWithConfigEntry):
         """Manage the options."""
         return self.async_show_menu(
             step_id="init",
-            menu_options=["login", "manual"],
+            menu_options=["login", "manual", "settings"],
+        )
+
+    async def async_step_settings(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Connection policy."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self.config_entry.title,
+                data={**self.config_entry.options, **user_input},
+            )
+        return self.async_show_form(
+            step_id="settings",
+            data_schema=_settings_schema(dict(self.config_entry.options)),
         )
 
     async def async_step_manual(

--- a/custom_components/tuya_ble/const.py
+++ b/custom_components/tuya_ble/const.py
@@ -18,6 +18,12 @@ SET_DISCONNECTED_DELAY = 10 * 60
 CONF_UUID: Final = "uuid"
 CONF_LOCAL_KEY: Final = "local_key"
 CONF_SEC_KEY: Final = "sec_key"
+
+# Connection policy (entry options)
+CONF_KEEP_CONNECTION: Final = "keep_connection"
+CONF_IDLE_DISCONNECT_DELAY: Final = "idle_disconnect_delay"
+DEFAULT_KEEP_CONNECTION: Final = True
+DEFAULT_IDLE_DISCONNECT_DELAY: Final = 30
 CONF_CATEGORY: Final = "category"
 CONF_PRODUCT_ID: Final = "product_id"
 CONF_DEVICE_NAME: Final = "device_name"

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -281,6 +281,10 @@ class TuyaBLECoordinator(DataUpdateCoordinator[None]):
 
     @property
     def connected(self) -> bool:
+        if not self._device.keep_connection:
+            # On-demand mode: the link is dropped on purpose between commands,
+            # so availability follows "has been reached", not "is connected".
+            return self._device.reachable
         return not self._disconnected
 
     @callback

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -664,7 +664,8 @@
                 "title": "Tuya BLE options",
                 "menu_options": {
                     "login": "Refresh credentials from Tuya IoT cloud",
-                    "manual": "Edit credentials manually"
+                    "manual": "Edit credentials manually",
+                    "settings": "Connection settings"
                 }
             },
             "manual": {
@@ -678,6 +679,14 @@
                     "product_id": "Product ID (e.g. neq16kgd)",
                     "category": "Category (e.g. szjqr for Fingerbots)",
                     "device_name": "Device name (optional)"
+                }
+            },
+            "settings": {
+                "title": "Connection settings",
+                "description": "Keep connection: the BLE link stays open permanently (fastest response, occupies one active connection slot on the adapter/proxy, higher battery drain on battery-powered devices). Off: connect on demand and disconnect after the idle delay (1–3 s latency per command).",
+                "data": {
+                    "keep_connection": "Keep BLE connection open",
+                    "idle_disconnect_delay": "Idle disconnect delay (seconds)"
                 }
             }
         }

--- a/custom_components/tuya_ble/translations/de.json
+++ b/custom_components/tuya_ble/translations/de.json
@@ -678,7 +678,8 @@
                 "title": "Tuya-BLE-Optionen",
                 "menu_options": {
                     "login": "Zugangsdaten aus der Tuya-IoT-Cloud neu abrufen",
-                    "manual": "Zugangsdaten manuell bearbeiten"
+                    "manual": "Zugangsdaten manuell bearbeiten",
+                    "settings": "Verbindungseinstellungen"
                 }
             },
             "manual": {
@@ -692,6 +693,14 @@
                     "product_id": "Product ID (z. B. neq16kgd)",
                     "category": "Kategorie (z. B. szjqr für Fingerbots)",
                     "device_name": "Gerätename (optional)"
+                }
+            },
+            "settings": {
+                "title": "Verbindungseinstellungen",
+                "description": "Verbindung halten: Die BLE-Verbindung bleibt dauerhaft offen (schnellste Reaktion, belegt einen aktiven Slot am Bluetooth-Adapter/-Proxy, höherer Batterieverbrauch). Aus: Verbindung nur bei Bedarf, Trennung nach der Leerlaufzeit (1–3 s Verzögerung pro Befehl).",
+                "data": {
+                    "keep_connection": "BLE-Verbindung dauerhaft halten",
+                    "idle_disconnect_delay": "Leerlaufzeit bis zur Trennung (Sekunden)"
                 }
             }
         }

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -678,7 +678,8 @@
                 "title": "Tuya BLE options",
                 "menu_options": {
                     "login": "Refresh credentials from Tuya IoT cloud",
-                    "manual": "Edit credentials manually"
+                    "manual": "Edit credentials manually",
+                    "settings": "Connection settings"
                 }
             },
             "manual": {
@@ -692,6 +693,14 @@
                     "product_id": "Product ID (e.g. neq16kgd)",
                     "category": "Category (e.g. szjqr for Fingerbots)",
                     "device_name": "Device name (optional)"
+                }
+            },
+            "settings": {
+                "title": "Connection settings",
+                "description": "Keep connection: the BLE link stays open permanently (fastest response, occupies one active connection slot on the adapter/proxy, higher battery drain on battery-powered devices). Off: connect on demand and disconnect after the idle delay (1–3 s latency per command).",
+                "data": {
+                    "keep_connection": "Keep BLE connection open",
+                    "idle_disconnect_delay": "Idle disconnect delay (seconds)"
                 }
             }
         }

--- a/custom_components/tuya_ble/tuya_ble/const.py
+++ b/custom_components/tuya_ble/tuya_ble/const.py
@@ -41,6 +41,9 @@ CONNECT_ATTEMPTS = 5
 RECONNECT_BACKOFF_MIN = 5
 RECONNECT_BACKOFF_MAX = 300
 
+# On-demand mode: seconds of inactivity before the link is dropped.
+DEFAULT_IDLE_DISCONNECT_DELAY = 30
+
 # Give the link time to settle after connect and retry the notify
 # subscription on transient GATT errors (e.g. 133 on ESP32 proxies).
 POST_CONNECT_DELAY = 0.3

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -765,6 +765,11 @@ class TuyaBLEDevice:
         return self._keep_connection
 
     @property
+    def idle_disconnect_delay(self) -> int:
+        """Return the idle timeout used in on-demand mode."""
+        return self._idle_disconnect_delay
+
+    @property
     def reachable(self) -> bool:
         """Return whether the device has been reached at least once."""
         return self._last_connected_at is not None

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -36,6 +36,7 @@ from .const import (
     NOTIFY_ATTEMPTS,
     NOTIFY_RETRY_DELAY,
     POST_CONNECT_DELAY,
+    DEFAULT_IDLE_DISCONNECT_DELAY,
     RECONNECT_BACKOFF_MAX,
     RECONNECT_BACKOFF_MIN,
     RESPONSE_WAIT_TIMEOUT,
@@ -290,6 +291,8 @@ class TuyaBLEDevice:
         device_manager: AbstaractTuyaBLEDeviceManager,
         ble_device: BLEDevice,
         advertisement_data: AdvertisementData | None = None,
+        keep_connection: bool = True,
+        idle_disconnect_delay: int = DEFAULT_IDLE_DISCONNECT_DELAY,
     ) -> None:
         """Init the TuyaBLE."""
         self._device_manager = device_manager
@@ -330,6 +333,13 @@ class TuyaBLEDevice:
         self._reconnect_task: asyncio.Task | None = None
         self._last_connect_error: str | None = None
         self._last_connected_at: float | None = None
+
+        # Connection policy: hold the link open, or connect on demand and
+        # drop it again after idle_disconnect_delay seconds of inactivity.
+        self._keep_connection = keep_connection
+        self._idle_disconnect_delay = idle_disconnect_delay
+        self._idle_task: asyncio.Task | None = None
+        self._idle_disconnecting = False
 
         self._input_buffer: bytearray | None = None
         self._input_expected_packet_num = 0
@@ -674,8 +684,10 @@ class TuyaBLEDevice:
         """Stop the TuyaBLE."""
         _LOGGER.debug("%s: Stop", self.address)
         self._stopped = True
-        if self._reconnect_task and not self._reconnect_task.done():
-            self._reconnect_task.cancel()
+        for task in (self._reconnect_task, self._idle_task):
+            if task and not task.done():
+                task.cancel()
+        self._idle_task = None
         await self._execute_disconnect()
 
     def _disconnected(self, client: BleakClientWithServiceCache) -> None:
@@ -704,9 +716,58 @@ class TuyaBLEDevice:
                 self.address,
                 self.rssi,
             )
-            asyncio.create_task(self._release_and_reconnect(dropped_client))
+            if self._keep_connection:
+                asyncio.create_task(self._release_and_reconnect(dropped_client))
+            else:
+                asyncio.create_task(self._release_client(dropped_client))
         elif dropped_client is not None:
             asyncio.create_task(self._release_client(dropped_client))
+
+    # ---- on-demand connection handling ----
+
+    def _touch(self) -> None:
+        """Note activity; (re)start the idle timer in on-demand mode."""
+        if self._keep_connection or self._stopped:
+            return
+        if self._idle_task and not self._idle_task.done():
+            self._idle_task.cancel()
+        self._idle_task = asyncio.create_task(self._idle_disconnect())
+
+    async def _idle_disconnect(self) -> None:
+        """Drop the link after a period without traffic."""
+        try:
+            await asyncio.sleep(self._idle_disconnect_delay)
+            while self._operation_lock.locked() or self._input_expected_responses:
+                await asyncio.sleep(1)
+            if self._stopped or not (self._client and self._client.is_connected):
+                return
+            _LOGGER.debug(
+                "%s: Idle for %ss, disconnecting",
+                self.address,
+                self._idle_disconnect_delay,
+            )
+            self._idle_disconnecting = True
+            try:
+                await asyncio.wait_for(self._execute_disconnect(), 10)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.debug("%s: Idle disconnect failed", self.address, exc_info=True)
+            finally:
+                await asyncio.sleep(0.5)
+                self._idle_disconnecting = False
+                self._expected_disconnect = False
+                self._is_paired = False
+        except asyncio.CancelledError:
+            pass
+
+    @property
+    def keep_connection(self) -> bool:
+        """Return whether the BLE link is held open permanently."""
+        return self._keep_connection
+
+    @property
+    def reachable(self) -> bool:
+        """Return whether the device has been reached at least once."""
+        return self._last_connected_at is not None
 
     async def _release_client(self, client: BleakClientWithServiceCache | None) -> None:
         """Let go of a connection that dropped on us.
@@ -779,7 +840,14 @@ class TuyaBLEDevice:
     async def _ensure_connected(self) -> None:
         """Ensure connection to device is established."""
         global global_connect_lock
-        if self._expected_disconnect or self._stopped:
+        if self._stopped:
+            return
+        # An idle disconnect may be in flight; let it finish before reconnecting.
+        while self._idle_disconnecting:
+            await asyncio.sleep(0.05)
+        if not self._keep_connection:
+            self._expected_disconnect = False
+        if self._expected_disconnect:
             return
         if self._connect_lock.locked():
             _LOGGER.debug(
@@ -953,6 +1021,7 @@ class TuyaBLEDevice:
                     self._last_connect_error = None
                     self._last_connected_at = time.monotonic()
                     self._fire_connected_callbacks()
+                    self._touch()
                 else:
                     _LOGGER.error("%s: Connected but not paired", self.address)
             else:
@@ -1200,6 +1269,7 @@ class TuyaBLEDevice:
         if self._stopped:
             return
         await self._send_packet_while_connected(code, data, 0, wait_for_response)
+        self._touch()
 
     async def _send_response(
         self,


### PR DESCRIPTION
Implements the last of the four items from #289.

Adds a third entry to the options menu, *Connection settings*, with two fields: **keep BLE connection open** (default on — current behaviour, nothing changes for existing entries) and **idle disconnect delay** (5–3600 s, default 30). Toggling the mode reloads the entry.

With the mode off, the device connects when a command arrives and the link is dropped again after the idle delay. An idle disconnect is a planned one: no reconnect is scheduled, and entity availability follows "device has been reached at least once" instead of "is currently connected" — otherwise every entity would grey out between commands. Any activity resets the timer, so a burst of commands shares one connection. Cost is 1–3 s latency per command.

Why it matters for battery devices: my Fingerbot Plus (`neq16kgd`) drops the link by itself every ~5 minutes at RSSI −48 to −55, the integration reconnects, and the cycle repeats around the clock — each pairing handshake being the most expensive thing the device does. Battery went from 100% to 40% in roughly three days on 0.11.x with the connection held. It also frees an active-connection slot on the adapter/proxy, which matters when one ESPHome proxy serves several devices (`habluetooth` logs "connect in progress and no fallback scanner" while a connect is in flight).

Tested on HA 2026.8 with the Fingerbot via an ESP32-S3 ESPHome proxy, in both modes; plus a simulated BLE client for the timer paths (idle disconnect fires, no reconnect follows, entities stay available, timer resets on activity, keep-connection mode still reconnects with backoff).

Nine files; English and German translations included. My own additions are Black-clean.
