### PR TITLE
fix(device): add support for EL605A Knob Lock (jtmspro/2hmqh0ty), index reversed mac addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ See a device marked Experimental you have? We could use real world testing feedb
       <td>—</td>
     </tr>
     <tr>
-      <td rowspan="24"><strong>Smart Locks</strong></td>
-      <td rowspan="24"><code>ms</code>, <code>jtmspro</code></td>
+      <td rowspan="25"><strong>Smart Locks</strong></td>
+      <td rowspan="25"><code>ms</code>, <code>jtmspro</code></td>
       <td>Smart Lock</td>
       <td><code>ludzroix</code>, <code>isk2p555</code>, <code>gumrixyt</code>, <code>uamrw6h3</code>, <code>sidhzylo</code>, <code>mqc2hevy</code>, <code>7a4xvbtt</code></td>
       <td>—</td>
@@ -251,6 +251,11 @@ See a device marked Experimental you have? We could use real world testing feedb
       <td>XCase NX-4964 Lock Box</td>
       <td><code>qicggi0m</code></td>
       <td>—</td>
+    </tr>
+    <tr>
+      <td>EL605A Knob Lock</td>
+      <td><code>2hmqh0ty</code></td>
+      <td>BLE unlock via DP71. Requires the FD50 device-info handshake.</td>
     </tr>
     <tr>
       <td>Example Product Securosmart lock</td>

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -193,6 +193,15 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
                     ),
                 ),
             ],
+            "2hmqh0ty": [  # EL605A Knob Lock
+                TuyaBLEButtonMapping(
+                    dp_id=71,  # Plain BLE unlock trigger, no encoded payload
+                    description=ButtonEntityDescription(
+                        key="bluetooth_unlock",
+                        icon="mdi:lock-open-variant-outline",
+                    ),
+                ),
+            ],
             **dict.fromkeys(
                 [
                     "stugc8dl",  # HU06 Smart Lock

--- a/custom_components/tuya_ble/cloud.py
+++ b/custom_components/tuya_ble/cloud.py
@@ -218,6 +218,18 @@ class HASSTuyaBLEDeviceManager(AbstaractTuyaBLEDeviceManager):
                             if sec_key:
                                 item.credentials[mac][CONF_SEC_KEY] = sec_key
 
+                            # Some devices (e.g. jtmspro knob locks) report the
+                            # MAC byte-reversed in the cloud factory info
+                            # compared to what they advertise over BLE, so the
+                            # credentials can never be matched to the scanned
+                            # device. Index the same entry under the reversed
+                            # address too. Existing keys win, so a device that
+                            # genuinely owns that address is never clobbered.
+                            reversed_mac = ":".join(reversed(mac.split(":")))
+                            item.credentials.setdefault(
+                                reversed_mac, item.credentials[mac]
+                            )
+
                             spec_response = await self._hass.async_add_executor_job(
                                 item.api.get,
                                 TUYA_API_DEVICE_SPECIFICATION % device.get("id"),

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -486,6 +486,7 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             "z7lj676i": TuyaBLEProductInfo(name="Smart Cylinder Lock", lock=1),
             "hs21i377": TuyaBLEProductInfo(name="Smart Cylinder Lock"),
             "kholoaew": TuyaBLEProductInfo(name="Smart Lock"),
+            "2hmqh0ty": TuyaBLEProductInfo(name="EL605A Knob Lock", lock=1),
             "pyawczjj": TuyaBLEProductInfo(name="CS-9 Smart Fingerprint Lock", lock=1),
             "yfqp0shy": TuyaBLEProductInfo(
                 name="Gainsborough Liberty BLE Lock (GGC01HA)", lock=1

--- a/custom_components/tuya_ble/lock.py
+++ b/custom_components/tuya_ble/lock.py
@@ -95,6 +95,19 @@ class TuyaBLELock(TuyaBLEEntity, LockEntity):
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
+        if self._device.product_id == "2hmqh0ty":
+            # EL605A knob lock: unlock is a DP71 (ble_unlock_check, Raw)
+            # trigger; a zero-length payload is enough. It also exposes
+            # manual_lock (DP46), so without this branch it would fall into
+            # the generic manual_lock path below and write DP46=False, which
+            # does not move the bolt. Verified on hardware.
+            if ble_unlock := self._device.datapoints.get_or_create(
+                71,
+                TuyaBLEDataPointType.DT_RAW,
+                b"",
+            ):
+                await ble_unlock.set_value(b"")
+            return
         manual_lock_id = self.find_dpid(DPCode.MANUAL_LOCK)
         if manual_lock_id is not None:
             if manual_lock := self._device.datapoints.get_or_create(

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -545,6 +545,9 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
     ),
     "jtmspro": TuyaBLECategorySensorMapping(
         products={
+            "2hmqh0ty": [  # EL605A Knob Lock
+                TuyaBLEBatteryMapping(dp_id=8),
+            ],
             **dict.fromkeys(
                 [
                     "y2yaegze",

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -62,14 +62,13 @@ from .exceptions import (
 from .manager import AbstaractTuyaBLEDeviceManager, TuyaBLEDeviceCredentials
 from .security import TuyaBLESecurityMaterial
 
-
 _LOGGER = logging.getLogger(__name__)
 
 
 BLEAK_EXCEPTIONS = (*BLEAK_RETRY_EXCEPTIONS, OSError)
 
 
-FD50_DEVICE_INFO_PRODUCT_IDS = frozenset({"jntxv3q4", "9hdajpiw"})
+FD50_DEVICE_INFO_PRODUCT_IDS = frozenset({"jntxv3q4", "9hdajpiw", "2hmqh0ty"})
 
 
 # @dataclass


### PR DESCRIPTION
Adds support for the EL605A Knob Lock (`jtmspro` / `2hmqh0ty`). AI-assisted but everything was tested by me (a human).

Had to fix some things to get this fully working:

1. Some devices report their MAC byte-reversed in the Tuya cloud factory info compared to what they broadcast over BLE, so the credentials can never be matched against the scanned device and setup fails with device_not_registered.
  - Now cached both ways, supports both conventions for devices

2. Added missing FD50 handshake

3. Added logic in `async_unlock` to support `ble_unlock_check` for EL605A .

**Testing:** two of these knobs over the same bluetooth proxy — connect, report state and battery, and physically unlock via `lock.unlock` and the button.